### PR TITLE
build: upgrade to pnpm v9.0.6, and make versioning more flexible

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false

--- a/examples/playground-movies/README.md
+++ b/examples/playground-movies/README.md
@@ -10,10 +10,10 @@ To run this example:
 npm --version
 ```
 
-2. Install [pnpm](https://pnpm.io/) version 8.7.0
+2. Install [pnpm](https://pnpm.io/)
 
 ```
-npm install -g pnpm@8.7.0
+npm install -g pnpm
 ```
 
 3. Clone the repo, and go to the directory for this example.

--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     "tsx": "^3.12.8",
     "turbo": "latest"
   },
-  "packageManager": "pnpm@8.7.0"
+  "packageManager": "pnpm@9.0.6"
 }


### PR DESCRIPTION
this change allows for future `pnpm` versions to be used without an unexpected build error. 

should be an overall plus, since `pnpm` releases are rather frequent e.g. https://github.com/pnpm/pnpm/releases

