### PR TITLE
update GitHub release workflow to support newer pnpm

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,9 +21,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: ⎔ Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v3.0.0
         with:
-          version: 8.7.0
+          version: 9.0.6
 
       - name: Setup Node.js 18
         uses: actions/setup-node@v3
@@ -32,7 +32,7 @@ jobs:
           cache: 'pnpm'
       
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
           
       - name: Build assets
         run: pnpm -w run build

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -31,15 +31,6 @@ jobs:
           node-version: 18
           cache: 'pnpm'
       
-      - name: DEBUG - List files
-        run: ls
-
-      - name: DEBUG - Show package-lock.yaml
-        run: more package-lock.yaml
-
-      - name: DEBUG - Install dependencies
-        run: pnpm install
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
           


### PR DESCRIPTION
remove "--frozen-lockfile" to increase flexibility as "pnpm" versions change