### PR TITLE
fix: show more informative error message if available

### DIFF
--- a/packages/core/providers/utils.ts
+++ b/packages/core/providers/utils.ts
@@ -194,6 +194,9 @@ export function setErrorInterceptor(showErrorsInput: string) {
       } else if (error.message) {
         friendlyMessage += "\nError message: " + error.message;
       }
+      if (error.response?.data?.message) {
+        friendlyMessage += "\n🛑 " + error.response.data.message;
+      }
 
       if (error.code === "ECONNABORTED") {
         friendlyMessage += "\nThe request timed out. Please try again later.";


### PR DESCRIPTION
example of a more informative error message is "Pipeline not found" (instead of "Request failed with status code 400")
