### PR TITLE
fix: update lock file for core dependencies

### DIFF
--- a/.changeset/bright-cougars-crash.md
+++ b/.changeset/bright-cougars-crash.md
@@ -1,5 +1,0 @@
----
-"@gentrace/core": patch
----
-
-fix: update lock file

--- a/.changeset/bright-cougars-crash.md
+++ b/.changeset/bright-cougars-crash.md
@@ -1,0 +1,5 @@
+---
+"@gentrace/core": patch
+---
+
+fix: update lock file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,9 +825,6 @@ importers:
       axios:
         specifier: ^1.4.0
         version: 1.5.0
-      express:
-        specifier: ^4.19.2
-        version: 4.21.1
       form-data:
         specifier: ^4.0.0
         version: 4.0.0
@@ -865,9 +862,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^11.1.0
         version: 11.1.3(rollup@3.28.1)(tslib@2.6.2)(typescript@5.1.6)
-      '@types/express':
-        specifier: ^5.0.0
-        version: 5.0.0
       '@types/jest':
         specifier: ^29.5.1
         version: 29.5.4


### PR DESCRIPTION
# Changes
* The express dependency is not in `core` so needed to regenerate lock file