### PR TITLE
feat: add variables to prompt parameters

### DIFF
--- a/.changeset/bright-rivers-remember.md
+++ b/.changeset/bright-rivers-remember.md
@@ -1,0 +1,6 @@
+---
+"@examples/evaluation": minor
+"@gentrace/core": minor
+---
+
+feat: add variables to prompt parameter

--- a/examples/evaluation/src/test-job-runner-webhook.ts
+++ b/examples/evaluation/src/test-job-runner-webhook.ts
@@ -24,6 +24,15 @@ const writeEmailPromptParameter = templateParameter({
   name: "Write email prompt",
   defaultValue:
     "Write an email to {{toEmail}} from ({{fromName}}) {{fromEmail}} according to these instructions: {{instructions}}",
+  variables: [
+    { name: "fromName", example: "John Doe" },
+    { name: "fromEmail", example: "john.doe@gmail.com" },
+    { name: "toEmail", example: "blah@gmail.com" },
+    {
+      name: "instructions",
+      example: { subject: "Hello", body: "Write a short email" },
+    },
+  ],
 });
 
 const writeEmail = defineInteraction({

--- a/examples/evaluation/src/test-job-runner.ts
+++ b/examples/evaluation/src/test-job-runner.ts
@@ -22,6 +22,15 @@ const writeEmailPromptParameter = templateParameter({
   name: "Write email prompt",
   defaultValue:
     "Write an email to {{toEmail}} from ({{fromName}}) {{fromEmail}} according to these instructions: {{instructions}}",
+  variables: [
+    { name: "fromName", example: "John Doe" },
+    { name: "fromEmail", example: "john.doe@gmail.com" },
+    { name: "toEmail", example: "blah@gmail.com" },
+    {
+      name: "instructions",
+      example: { subject: "Hello", body: "Write a short email" },
+    },
+  ],
 });
 
 const writeEmail = defineInteraction({

--- a/packages/core/providers/test-job-runner.ts
+++ b/packages/core/providers/test-job-runner.ts
@@ -252,6 +252,7 @@ type Parameter =
       type: "template";
       name: string;
       defaultValue: string;
+      variables: { name: string; example: any }[];
     };
 
 export const numericParameter = ({
@@ -311,21 +312,24 @@ export const enumParameter = ({
   };
 };
 
-export const templateParameter = ({
+export const templateParameter = <T extends Record<string, any>>({
   name,
   defaultValue,
+  variables,
 }: {
   name: string;
   defaultValue: string;
+  variables?: { name: keyof T; example: T[keyof T] }[];
 }) => {
   parameters[name] = {
     name,
     type: "template",
     defaultValue,
+    variables: variables ? (variables as { name: string; example: any }[]) : [],
   };
   return {
     name,
-    render: (values: Record<string, any>) => {
+    render: (values: T) => {
       const overrides = overridesAsyncLocalStorage.getStore();
       const template = overrides?.[name] ?? defaultValue;
       return Mustache.render(template, values);


### PR DESCRIPTION
# Changes
* Add a `variables` optional property to prompt parameter type
  * Question: Is this duplicative with the `inputType` that is provided for validation? Is there a more concise way of doing this?
  
Errors if types don't align:
![Screenshot 2024-12-03 at 11 15 06 AM](https://github.com/user-attachments/assets/f2de47b8-f458-40af-8606-a04927004795)
![Screenshot 2024-12-03 at 11 15 16 AM](https://github.com/user-attachments/assets/08acfdd6-dbc4-41be-8e5f-9b1d9b714dfd)

Depends on: https://github.com/gentrace/gentrace/pull/3821

Fixes: GT-1121