### PR TITLE
feat: provide image urls for llm evals

### DIFF
--- a/.changeset/eight-jobs-lie.md
+++ b/.changeset/eight-jobs-lie.md
@@ -1,0 +1,5 @@
+---
+"@gentrace/evals": patch
+---
+
+feat: provide image urls for llm evals


### PR DESCRIPTION
# Changes
* Pass in provided image URLs to llm evals so they can be used in the evaluation

Example:
![Screenshot 2024-12-09 at 9 49 21 AM](https://github.com/user-attachments/assets/f948c4e7-f7ee-4b86-baeb-29958f4be67e)
<img width="382" alt="Screenshot 2024-12-09 at 9 49 39 AM" src="https://github.com/user-attachments/assets/33f85c17-7b2e-4128-bb6f-7ba7b16096fb">
