### PR TITLE
fix: Add `Baggage` to the interaction to `gentrace.sample`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 init({
-  apiKey: process.env.GENTRACE_API_KEY,
+  bearerToken: process.env.GENTRACE_API_KEY,
   // Optional: Specify base URL if using self-hosted or enterprise Gentrace
   // The format should be: http(s)://<hostname>/api
   // baseURL: process.env.GENTRACE_BASE_URL,
@@ -86,7 +86,7 @@ import { queryAi } from './aiFunctions'; // Assuming your function is here
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 
 init({
-  apiKey: process.env.GENTRACE_API_KEY,
+  bearerToken: process.env.GENTRACE_API_KEY,
 });
 
 // Omitted OpenTelemetry setup (view the OTEL section below)
@@ -99,8 +99,8 @@ export const instrumentedQueryAi = interaction(
 
 // Example of calling the instrumented function
 async function run() {
-  const result = await instrumentedQueryAi({ query: 'Explain quantum computing simply.' });
-  console.log('AI Response:', result);
+  const explanation = await instrumentedQueryAi({ query: 'Explain quantum computing simply.' });
+  console.log('Explanation:', explanation);
 }
 
 run();
@@ -129,17 +129,19 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 init({
-  apiKey: process.env.GENTRACE_API_KEY,
+  bearerToken: process.env.GENTRACE_API_KEY,
 });
+
+// Omitted OpenTelemetry setup (view the OTEL section below)
 
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   test('simple-query-test', async () => {
-    const result = await instrumentedQueryAi({ query: 'What is the capital of France?' });
+    const capital = await instrumentedQueryAi({ query: 'What is the capital of France?' });
     // You can add assertions here if needed, exceptions will get captured and recorded on the
     // test span.
-    console.log('Test Result:', result);
+    console.log('Capital:', capital);
     return result; // Return value is captured in the span
   });
 
@@ -159,6 +161,9 @@ npx ts-node src/tests/simple.ts
 
 Results will be available in the experiment section corresponding to that particular pipeline.
 
+> [!WARNING]  
+> This testing example assumes you have already set up OpenTelemetry as described in the [OpenTelemetry Integration](#opentelemetry-integration) section, since we're using an instrumented function call that uses the OTEL SDK.
+
 ### Testing with Datasets (`testDataset`)
 
 You can run your instrumented functions against datasets defined in Gentrace. This is useful for regression testing and evaluating performance across many examples.
@@ -175,8 +180,10 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 init({
-  apiKey: process.env.GENTRACE_API_KEY,
+  bearerToken: process.env.GENTRACE_API_KEY,
 });
+
+// Omitted OpenTelemetry setup (view the OTEL section below)
 
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 const GENTRACE_DATASET_ID = process.env.GENTRACE_DATASET_ID!;
@@ -245,7 +252,7 @@ dotenv.config();
 const GENTRACE_API_KEY = process.env.GENTRACE_API_KEY!;
 
 init({
-  apiKey: GENTRACE_API_KEY,
+  bearerToken: GENTRACE_API_KEY,
 });
 
 // ====> COPY: Begin OpenTelemetry tracing

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ experiment(GENTRACE_PIPELINE_ID, async () => {
 });
 ```
 
-> Note: While `zod` is used in the example, any schema validation library that conforms to the [Standard Schema](https://github.com/standard-schema/standard-schema) interface (like `zod`, `valibot`, `arktype`, etc.) can be used for the `schema` parameter. This interface requires the library to expose a `parse()` function, which `testDataset` uses internally.
+> [!NOTE]  
+> While `zod` is used in the example, any schema validation library that conforms to the [Standard Schema](https://github.com/standard-schema/standard-schema) interface (like `zod`, `valibot`, `arktype`, etc.) can be used for the `schema` parameter. This interface requires the library to expose a `parse()` function, which `testDataset` uses internally.
 
 Run the dataset test:
 
@@ -222,7 +223,8 @@ Gentrace will execute `instrumentedQueryAi` for each test case in your dataset a
 
 OpenTelemetry integration is **required** for the Gentrace SDK's instrumentation features (`interaction`, `test`, `testDataset`) to function correctly. You must set up the OpenTelemetry SDK to capture and export traces to Gentrace.
 
-> **Note:** Modern package managers (like `pnpm` 8+, `yarn` 2+, and `npm` 7+) should automatically install these peer dependencies when you install `gentrace`. If the packages weren't already installed, you might need to install them manually.
+> [!NOTE]  
+> Modern package managers (like `pnpm` 8+, `yarn` 2+, and `npm` 7+) should automatically install these peer dependencies when you install `gentrace`. If the packages weren't already installed, you might need to install them manually.
 
 <details>
 <summary>Click here to view the command for installing OpenTelemetry peer dependencies manually</summary>

--- a/README.md
+++ b/README.md
@@ -244,11 +244,14 @@ The described OpenTelemetry setup supports both v1 and v2 of the spec, although 
 import dotenv from 'dotenv';
 import { init } from 'gentrace';
 
+// 📋 Start copying OTEL imports
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+// 📋 End copying imports
 
 dotenv.config();
 
@@ -258,10 +261,10 @@ init({
   bearerToken: GENTRACE_API_KEY,
 });
 
-// ====> COPY: Begin OpenTelemetry tracing
+// 📋 Start copying OTEL setup
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: 'openai-email-composition-simplified',
+    [ATTR_SERVICE_NAME]: 'your-generative-ai-feature',
   }),
   traceExporter: new OTLPTraceExporter({
     url: 'https://gentrace.ai/api/otel/v1/traces',
@@ -287,15 +290,7 @@ process.on('beforeExit', async () => {
 process.on('SIGTERM', async () => {
   await sdk.shutdown();
 });
-// ====> COPY: End OpenTelemetry tracing
-
-// Now, any code run in this process that uses instrumented libraries
-// (or manual OTel tracing) will send traces to Gentrace.
-// You can still use `interaction` alongside this for specific function tracing.
-
-// Example: Your application logic starts here
-// import { instrumentedQueryAi } from './instrumentedAi';
-// instrumentedQueryAi({ query: "What is OpenTelemetry?" });
+// 📋 End copying OpenTelemetry setup
 ```
 
 See the `examples/` directory for runnable examples demonstrating these concepts with OpenTelemetry.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ init({
   bearerToken: process.env.GENTRACE_API_KEY,
 });
 
-// Omitted OpenTelemetry setup (view the OTEL section below)
+// 🚧 Add OpenTelemetry setup (view the OTEL section below)
 
 // Create an instrumented version of your function
 export const instrumentedQueryAi = interaction(
@@ -132,7 +132,7 @@ init({
   bearerToken: process.env.GENTRACE_API_KEY,
 });
 
-// Omitted OpenTelemetry setup (view the OTEL section below)
+// 🚧 Add OpenTelemetry setup (view the OTEL section below)
 
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 
@@ -183,7 +183,7 @@ init({
   bearerToken: process.env.GENTRACE_API_KEY,
 });
 
-// Omitted OpenTelemetry setup (view the OTEL section below)
+// 🚧 Add OpenTelemetry setup (view the OTEL section below)
 
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 const GENTRACE_DATASET_ID = process.env.GENTRACE_DATASET_ID!;

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ First, initialize the SDK with your Gentrace API key. You typically do this once
 <!-- prettier-ignore -->
 ```typescript
 import { init } from 'gentrace';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 init({
   bearerToken: process.env.GENTRACE_API_KEY,
@@ -77,7 +74,7 @@ export async function queryAi({ query }: { query: string }): Promise<string | nu
 
 Now, wrap it with `interaction`:
 
-**`src/instrumentedAi.ts`**:
+**`src/run.ts`**:
 
 <!-- prettier-ignore -->
 ```typescript
@@ -107,6 +104,10 @@ async function run() {
 run();
 ```
 
+```sh
+GENTRACE_PIPELINE_ID=<your-pipeline-id> GENTRACE_API_KEY=<your-api-key> npx ts-node src/run.ts
+```
+
 > [!WARNING]  
 > This example assumes you have already set up OpenTelemetry as described in the [OpenTelemetry Integration](#opentelemetry-integration) section. The `interaction` function requires this setup to capture and send traces.
 > Now, every time `instrumentedQueryAi` is called, Gentrace will record a trace associated with your `GENTRACE_PIPELINE_ID`.
@@ -125,17 +126,15 @@ Use `experiment` to group tests and `test` to define individual test cases.
 ```typescript
 import { init, experiment, test } from 'gentrace';
 import { instrumentedQueryAi } from '../instrumentedAi'; // Your instrumented function
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 init({
   bearerToken: process.env.GENTRACE_API_KEY,
 });
 
+const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
+
 // 🚧 Add OpenTelemetry setup (view the OTEL section below)
 
-const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   test('simple-query-test', async () => {
@@ -157,7 +156,7 @@ experiment(GENTRACE_PIPELINE_ID, async () => {
 To run these tests, simply execute the file:
 
 ```sh
-npx ts-node src/tests/simple.ts
+GENTRACE_PIPELINE_ID=<your-pipeline-id> GENTRACE_API_KEY=<your-api-key> npx ts-node src/tests/simple.ts
 ```
 
 Results will be available in the experiment section corresponding to that particular pipeline.
@@ -176,9 +175,6 @@ You can run your instrumented functions against datasets defined in Gentrace. Th
 import { init, experiment, testDataset, testCases } from 'gentrace';
 import { instrumentedQueryAi } from '../instrumentedAi'; // Your instrumented function
 import { z } from 'zod'; // For defining input schema
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 init({
   bearerToken: process.env.GENTRACE_API_KEY,
@@ -215,7 +211,7 @@ experiment(GENTRACE_PIPELINE_ID, async () => {
 Run the dataset test:
 
 ```sh
-npx ts-node src/tests/dataset.ts
+GENTRACE_PIPELINE_ID=<your-pipeline-id> GENTRACE_DATASET_ID=<your-dataset-id> GENTRACE_API_KEY=<your-api-key> npx ts-node src/tests/dataset.ts
 ```
 
 Gentrace will execute `instrumentedQueryAi` for each test case in your dataset and record the results.
@@ -241,7 +237,6 @@ The described OpenTelemetry setup supports both v1 and v2 of the spec, although 
 
 <!-- prettier-ignore -->
 ```typescript
-import dotenv from 'dotenv';
 import { init } from 'gentrace';
 
 // 📋 Start copying OTEL imports
@@ -252,8 +247,6 @@ import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 // 📋 End copying imports
-
-dotenv.config();
 
 const GENTRACE_API_KEY = process.env.GENTRACE_API_KEY!;
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ init({
 // 📋 Start copying OTEL setup
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: 'your-generative-ai-feature',
+    [ATTR_SERVICE_NAME]: 'your-generative-ai-product',
   }),
   traceExporter: new OTLPTraceExporter({
     url: 'https://gentrace.ai/api/otel/v1/traces',

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This library provides tools to instrument and test your AI applications using Gentrace.
 
-The full API documentation can be found in [api.md](api.md).
+The API reference documentation, auto-generated from our Stainless client code, can be found in [api.md](api.md).
 
 ## Installation
 
@@ -23,7 +23,8 @@ The Gentrace SDK provides several key functions to help you instrument and evalu
 - **`test`**: Runs a single test case within an experiment. ([Requires OpenTelemetry](#opentelemetry-integration))
 - **`testDataset`**: Runs tests based on a dataset defined in Gentrace. ([Requires OpenTelemetry](#opentelemetry-integration))
 
-> **Important:** The instrumentation features (`interaction`, `test`, `testDataset`) rely on OpenTelemetry being configured. Please see the [OpenTelemetry Integration](#opentelemetry-integration) section for setup instructions before using these features.
+> [!NOTE]
+> The instrumentation features (`interaction`, `test`, `testDataset`) rely on OpenTelemetry being configured. Please see the [OpenTelemetry Integration](#opentelemetry-integration) section for setup instructions before using these features.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Gentrace will execute `instrumentedQueryAi` for each test case in your dataset a
 OpenTelemetry integration is **required** for the Gentrace SDK's instrumentation features (`interaction`, `test`, `testDataset`) to function correctly. You must set up the OpenTelemetry SDK to capture and export traces to Gentrace.
 
 > [!NOTE]  
-> Modern package managers (like `pnpm` 8+, `yarn` 2+, and `npm` 7+) should automatically install these peer dependencies when you install `gentrace`. If the packages weren't already installed, you might need to install them manually.
+> Modern package managers (like `pnpm` 8+, `yarn` 2+, and `npm` 7+) should automatically install the OTEL dependencies when you install `gentrace`. If the packages weren't already installed, you might need to install them manually.
 
 <details>
 <summary>Click here to view the command for installing OpenTelemetry peer dependencies manually</summary>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The Gentrace SDK provides several key functions to help you instrument and evalu
 - **`test`**: Runs a single test case within an experiment. ([Requires OpenTelemetry](#opentelemetry-integration))
 - **`testDataset`**: Runs tests based on a dataset defined in Gentrace. ([Requires OpenTelemetry](#opentelemetry-integration))
 
+> **Important:** The instrumentation features (`interaction`, `test`, `testDataset`) rely on OpenTelemetry being configured. Please see the [OpenTelemetry Integration](#opentelemetry-integration) section for setup instructions before using these features.
+
 ## Basic Usage
 
 ### Initialization
@@ -78,10 +80,16 @@ Now, wrap it with `interaction`:
 
 <!-- prettier-ignore -->
 ```typescript
-import { interaction } from 'gentrace';
+import { init, interaction } from 'gentrace';
 import { queryAi } from './aiFunctions'; // Assuming your function is here
 
 const GENTRACE_PIPELINE_ID = process.env.GENTRACE_PIPELINE_ID!;
+
+init({
+  apiKey: process.env.GENTRACE_API_KEY,
+});
+
+// Omitted OpenTelemetry setup (view the OTEL section below)
 
 // Create an instrumented version of your function
 export const instrumentedQueryAi = interaction(
@@ -98,7 +106,9 @@ async function run() {
 run();
 ```
 
-Now, every time `instrumentedQueryAi` is called, Gentrace will record a trace associated with your `GENTRACE_PIPELINE_ID`.
+> [!WARNING]  
+> This example assumes you have already set up OpenTelemetry as described in the [OpenTelemetry Integration](#opentelemetry-integration) section. The `interaction` function requires this setup to capture and send traces.
+> Now, every time `instrumentedQueryAi` is called, Gentrace will record a trace associated with your `GENTRACE_PIPELINE_ID`.
 
 ## Testing and Evaluation
 
@@ -224,9 +234,10 @@ The described OpenTelemetry setup supports both v1 and v2 of the spec, although 
 import dotenv from 'dotenv';
 import { init } from 'gentrace';
 
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
-import { NodeSDK } from '@opentelemetry/sdk-node';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 
 dotenv.config();

--- a/README.md
+++ b/README.md
@@ -233,8 +233,6 @@ dotenv.config();
 
 const GENTRACE_API_KEY = process.env.GENTRACE_API_KEY!;
 
-const OTEL_ENDPOINT = 'https://gentrace.ai/api/otel/v1/traces';
-
 init({
   apiKey: GENTRACE_API_KEY,
 });
@@ -245,7 +243,7 @@ const sdk = new NodeSDK({
     [ATTR_SERVICE_NAME]: 'openai-email-composition-simplified',
   }),
   traceExporter: new OTLPTraceExporter({
-    url: OTEL_ENDPOINT,
+    url: 'https://gentrace.ai/api/otel/v1/traces',
     headers: {
       Authorization: `Bearer ${GENTRACE_API_KEY}`,
     },

--- a/examples/openai-composition.ts
+++ b/examples/openai-composition.ts
@@ -7,6 +7,19 @@ import { readEnv } from 'gentrace/internal/utils';
 import { init } from '../src/lib/init';
 import { interaction } from '../src/lib/interaction';
 import { composeEmail } from './functions/composition';
+import { Attributes, Context, Link, propagation, SpanKind } from '@opentelemetry/api';
+import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  ConsoleSpanExporter,
+  Sampler,
+  SamplingDecision,
+  SamplingResult,
+  SimpleSpanProcessor,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { OpenAIInstrumentation } from '@traceloop/instrumentation-openai';
+import process from 'process';
 
 const GENTRACE_BASE_URL = readEnv('GENTRACE_BASE_URL');
 const GENTRACE_PIPELINE_ID = readEnv('GENTRACE_PIPELINE_ID')!;
@@ -27,21 +40,106 @@ const resource = resourceFromAttributes({
   [ATTR_SERVICE_NAME]: 'openai-email-composition-simplified',
 });
 
+class GentraceSampler implements Sampler {
+  shouldSample(
+    context: Context,
+    traceId: string,
+    spanName: string,
+    spanKind: SpanKind,
+    attributes: Attributes,
+    links: Link[],
+  ): SamplingResult {
+    const currentMomentBaggage = propagation.getBaggage(context);
+    const sampleEntry = currentMomentBaggage?.getEntry('gentrace.sample');
+
+    if ((currentMomentBaggage && sampleEntry?.value === 'true') || attributes['gentrace.sample'] === 'true') {
+      return { decision: SamplingDecision.RECORD_AND_SAMPLED };
+    } else {
+      return { decision: SamplingDecision.NOT_RECORD };
+    }
+  }
+
+  toString(): string {
+    return 'GentraceSampler';
+  }
+}
+
+const contextManager = new AsyncLocalStorageContextManager();
+contextManager.enable();
+
+const isEdgeRuntime = process.env['NEXT_RUNTIME'] === 'edge';
+const instrumentations =
+  isEdgeRuntime ?
+    []
+  : [
+      new OpenAIInstrumentation({
+        exceptionLogger: (e: Error) => {
+          console.error('Error logging OpenAI exception', e);
+        },
+      }),
+    ];
+
+const baggageProcessor = new BaggageSpanProcessor((baggageKey: string) => {
+  console.log('baggageKey', baggageKey);
+  return baggageKey === 'gentrace.sample';
+});
+
+let spanProcessors: SpanProcessor[];
+let sampler: Sampler | undefined = undefined;
+
+if (process.env['ENVIRONMENT'] === 'production') {
+  // In production, we head sample using the gentrace.sample attribute
+  // in the OTEL collector. The baggage processor moves the gentrace.sample
+  // attribute to the trace attributes, as the baggage won't be available
+  // in the collector.
+  spanProcessors = [baggageProcessor];
+  resource.attributes['env'] = 'production';
+  resource.attributes['node.env'] = 'production';
+} else {
+  console.log('Development environment detected');
+  const traceExporter = new OTLPTraceExporter({
+    url: `${GENTRACE_BASE_URL}/otel/v1/traces`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${readEnv('GENTRACE_API_KEY')}`,
+    },
+  });
+
+  // In development, we need to manually setup the sampling and exporter.
+  // Note: the sampler runs BEFORE the baggage processor, so we need to
+  // check both baggage and attributes.
+  spanProcessors = [
+    baggageProcessor,
+    new SimpleSpanProcessor(traceExporter),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ];
+  sampler = new GentraceSampler();
+
+  resource.attributes['env'] = 'development';
+  resource.attributes['node.env'] = 'development';
+}
+
 // Begin OpenTelemetry SDK setup
 const sdk = new NodeSDK({
   resource,
-  traceExporter: new OTLPTraceExporter({
-    url: `${GENTRACE_BASE_URL}/otel/v1/traces`,
-    headers: {
-      Authorization: `Bearer ${readEnv('GENTRACE_API_KEY')}`,
-    },
-  }),
+  instrumentations,
+  spanProcessors,
+  ...(sampler && { sampler }), // Conditionally add sampler if defined
+  contextManager,
 });
 
 sdk.start();
 
-process.on('SIGTERM', () => {
-  sdk
+process.on('beforeExit', async () => {
+  await sdk
+    .shutdown()
+    .then(() => console.log('Tracing terminated.'))
+    .catch((error) => console.log('Error terminating tracing', error))
+    .finally(() => process.exit(0));
+});
+
+process.on('SIGTERM', async () => {
+  await sdk
     .shutdown()
     .then(() => console.log('Tracing terminated.'))
     .catch((error) => console.log('Error terminating tracing', error))
@@ -49,15 +147,10 @@ process.on('SIGTERM', () => {
 });
 // End OpenTelemetry SDK setup
 
-const compose = interaction(
-  GENTRACE_PIPELINE_ID,
-  async ({ recipient, topic, sender }: { recipient: string; topic: string; sender: string }) => {
-    return await composeEmail(recipient, topic, sender);
-  },
-);
+const compose = interaction(GENTRACE_PIPELINE_ID, composeEmail);
 
 async function main() {
-  const draft = await compose({ recipient: 'Alice', topic: 'Project Phoenix Update', sender: 'John Doe' });
+  const draft = await compose('Alice', 'Project Phoenix Update', 'John Doe');
   console.log('Draft:', draft);
 }
 

--- a/examples/openai-composition.ts
+++ b/examples/openai-composition.ts
@@ -79,10 +79,7 @@ const instrumentations =
       }),
     ];
 
-const baggageProcessor = new BaggageSpanProcessor((baggageKey: string) => {
-  console.log('baggageKey', baggageKey);
-  return baggageKey === 'gentrace.sample';
-});
+const baggageProcessor = new BaggageSpanProcessor((baggageKey: string) => baggageKey === 'gentrace.sample');
 
 let spanProcessors: SpanProcessor[];
 let sampler: Sampler | undefined = undefined;
@@ -96,7 +93,6 @@ if (process.env['ENVIRONMENT'] === 'production') {
   resource.attributes['env'] = 'production';
   resource.attributes['node.env'] = 'production';
 } else {
-  console.log('Development environment detected');
   const traceExporter = new OTLPTraceExporter({
     url: `${GENTRACE_BASE_URL}/otel/v1/traces`,
     headers: {

--- a/examples/test-openai-composition.ts
+++ b/examples/test-openai-composition.ts
@@ -51,15 +51,10 @@ process.on('SIGTERM', async () => {
 });
 // End OpenTelemetry SDK setup
 
-const compose = interaction(
-  GENTRACE_PIPELINE_ID,
-  async ({ recipient, topic, sender }: { recipient: string; topic: string; sender: string }) => {
-    return await composeEmail(recipient, topic, sender);
-  },
-);
+const compose = interaction(GENTRACE_PIPELINE_ID, composeEmail);
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   await test('Simplified Test Case', async () => {
-    return await compose({ recipient: 'TestRecipient', topic: 'TestTopic', sender: 'TestSender' });
+    return await compose('TestRecipient', 'TestTopic', 'TestSender');
   });
 });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/baggage-span-processor": "^0.4.0",
     "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
@@ -36,6 +37,7 @@
     "@opentelemetry/semantic-conventions": "^1.32.0",
     "@swc/core": "^1.3.102",
     "@swc/jest": "^0.2.29",
+    "@traceloop/instrumentation-openai": "^0.13.0",
     "@types/jest": "^29.4.0",
     "@types/json-stringify-safe": "^5.0.3",
     "@types/node": "^22.14.1",
@@ -68,7 +70,8 @@
     "@opentelemetry/resources": ">=1.0.0 <3.0.0",
     "@opentelemetry/sdk-node": ">=0.49.0 <0.300.0",
     "@opentelemetry/sdk-trace-node": ">=1.0.0 <3.0.0",
-    "@opentelemetry/semantic-conventions": ">=1.0.0 <2.0.0"
+    "@opentelemetry/semantic-conventions": ">=1.0.0 <2.0.0",
+    "@opentelemetry/baggage-span-processor": ">=0.1.0 <0.5.0"
   },
   "resolutions": {
     "synckit": "0.8.8"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,4 +8,5 @@ export {
 } from './experiment-control';
 export { interaction } from './interaction';
 export { testDataset } from './test-dataset';
+export { traced } from './traced';
 export { test } from './test-single';

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -1,3 +1,4 @@
+import { context, propagation } from '@opentelemetry/api';
 import { ANONYMOUS_SPAN_NAME } from './constants';
 import { TracedOptions, traced } from './traced';
 
@@ -33,5 +34,16 @@ export function interaction<F extends (...args: any[]) => any>(
     },
   });
 
-  return wrappedFn as F;
+  const finalWrappedFn = (...args: Parameters<F>): ReturnType<F> => {
+    const currentContext = context.active();
+    const currentBaggage = propagation.getBaggage(currentContext) ?? propagation.createBaggage();
+
+    const newBaggage = currentBaggage.setEntry('gentrace.sample', {
+      value: 'true',
+    });
+    const newContext = propagation.setBaggage(currentContext, newBaggage);
+    return context.with(newContext, () => wrappedFn(...args));
+  };
+
+  return finalWrappedFn as F;
 }

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -42,7 +42,7 @@ export function interaction<F extends (...args: any[]) => any>(
       value: 'true',
     });
     const newContext = propagation.setBaggage(currentContext, newBaggage);
-    return context.with(newContext, () => wrappedFn(...args));
+    return context.bind(newContext, wrappedFn)(...args);
   };
 
   return finalWrappedFn as F;

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,10 +953,24 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
+"@opentelemetry/api-logs@0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz#68f8c51ca905c260b610c8a3c67d3f9fa3d59a45"
+  integrity sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
 "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
+"@opentelemetry/baggage-span-processor@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/baggage-span-processor/-/baggage-span-processor-0.4.0.tgz#7912628a79c099944fdb4c866e56534cc9cf8433"
+  integrity sha512-BSYnnKAAyrIsxQNKPUuawEfvvO9eqDh7TnPR6SWGR53XQrYr0VTv81jRbMQ3jHtKzno6MQQ1zTcCWgnjUKcBWw==
+  dependencies:
+    "@opentelemetry/sdk-trace-base" "^2.0.0"
 
 "@opentelemetry/context-async-hooks@2.0.0", "@opentelemetry/context-async-hooks@^2.0.0":
   version "2.0.0"
@@ -969,6 +983,13 @@
   integrity sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/core@^1.29.0":
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.30.1.tgz#a0b468bb396358df801881709ea38299fc30ab27"
+  integrity sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.28.0"
 
 "@opentelemetry/exporter-logs-otlp-grpc@0.200.0":
   version "0.200.0"
@@ -1108,6 +1129,18 @@
     require-in-the-middle "^7.1.1"
     shimmer "^1.2.1"
 
+"@opentelemetry/instrumentation@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz#3330ce16d9235a548efa1019a4a7f01414edd44a"
+  integrity sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.56.0"
+    "@types/shimmer" "^1.2.0"
+    import-in-the-middle "^1.8.1"
+    require-in-the-middle "^7.1.1"
+    semver "^7.5.2"
+    shimmer "^1.2.1"
+
 "@opentelemetry/otlp-exporter-base@0.200.0":
   version "0.200.0"
   resolved "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz"
@@ -1206,7 +1239,7 @@
     "@opentelemetry/sdk-trace-node" "2.0.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@2.0.0":
+"@opentelemetry/sdk-trace-base@2.0.0", "@opentelemetry/sdk-trace-base@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz"
   integrity sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==
@@ -1224,7 +1257,12 @@
     "@opentelemetry/core" "2.0.0"
     "@opentelemetry/sdk-trace-base" "2.0.0"
 
-"@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.32.0":
+"@opentelemetry/semantic-conventions@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz#337fb2bca0453d0726696e745f50064411f646d6"
+  integrity sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==
+
+"@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.32.0":
   version "1.32.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.32.0.tgz"
   integrity sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ==
@@ -1400,6 +1438,25 @@
   integrity sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==
   dependencies:
     "@swc/counter" "^0.1.3"
+
+"@traceloop/ai-semantic-conventions@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@traceloop/ai-semantic-conventions/-/ai-semantic-conventions-0.13.0.tgz#8cac4f91e23e110a6024105ec6a28a2ef4878499"
+  integrity sha512-6aAbaZkeezijSBnsKpVnc+MBXwG+ByDK70gZCexSykkwkwhWSFdVeoXkWUBeLt+STFQWjK5EQE087qkaVC3o+w==
+  dependencies:
+    "@opentelemetry/api" "^1.9.0"
+
+"@traceloop/instrumentation-openai@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@traceloop/instrumentation-openai/-/instrumentation-openai-0.13.0.tgz#c2defd89e98059eb6f6e704b349525f6c743e77b"
+  integrity sha512-ql9ML/zV4uHc5RnrpuismJluYiVDo9TXxIMqz1PSe2uFuzt6d7RDil9tbjXbwNlCfeyIEBGY/UJZCuUYneXUdw==
+  dependencies:
+    "@opentelemetry/core" "^1.29.0"
+    "@opentelemetry/instrumentation" "^0.56.0"
+    "@opentelemetry/semantic-conventions" "^1.28.0"
+    "@traceloop/ai-semantic-conventions" "^0.13.0"
+    js-tiktoken "^1.0.15"
+    tslib "^2.8.1"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -1842,6 +1899,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3303,6 +3365,13 @@ jest@^29.4.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+js-tiktoken@^1.0.15:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.20.tgz#fa2733bf147acaf1bdcf9ab8a878e79c581c95f2"
+  integrity sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==
+  dependencies:
+    base64-js "^1.5.1"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -4065,6 +4134,11 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
+semver@^7.5.2, semver@^7.6.0:
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
@@ -4076,11 +4150,6 @@ semver@^7.5.4:
   version "7.6.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-semver@^7.6.0:
-  version "7.7.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Background

We're introducing OTLP baggage to interactions to make sure that every span underneath an interaction has `gentrace.sample`. 

This does require users to provide a `BaggageSpanProcessor` to apply the baggage attributes to the span. I've included an example in `openai-composition.ts` to show how this is done.

**Remaining items**
- [x] Documentation for users to create a `BaggageSpanProcessor` that applies baggage to the spans