### PR TITLE
chore: Remove test_case_name attribute

### DIFF
--- a/src/lib/eval-dataset.ts
+++ b/src/lib/eval-dataset.ts
@@ -86,8 +86,6 @@ export async function evalDataset<
     const spanAttributes: Record<string, string> = {};
     if (typeof finalId === 'string') {
       spanAttributes['gentrace.test_case_id'] = finalId;
-    } else {
-      spanAttributes['gentrace.test_case_name'] = finalName;
     }
 
     promises.push(

--- a/src/lib/eval-once.ts
+++ b/src/lib/eval-once.ts
@@ -28,7 +28,6 @@ export async function evalOnce<TResult>(
 ): Promise<TResult | null> {
   return _runEval<TResult, any>({
     spanName,
-    spanAttributes: { 'gentrace.test_case_name': spanName },
     callback,
   });
 }
@@ -56,7 +55,7 @@ export type RunEvalParams<T> = {
  */
 export type RunEvalInternalOptions<TResult, TInput> = {
   spanName: string;
-  spanAttributes: Record<string, string>;
+  spanAttributes?: Record<string, string>;
   inputs?: unknown | undefined;
   schema?: ParseableSchema<TInput> | undefined;
   callback: (parsedData: TInput) => TResult | null | Promise<TResult | null>;
@@ -90,7 +89,7 @@ export async function _runEval<TResult, TInput = any>(
   return new Promise<TResult | null>((resolve) => {
     tracer.startActiveSpan(spanName, async (span: Span) => {
       span.setAttribute('gentrace.experiment_id', experimentId);
-      Object.entries(spanAttributes).forEach(([key, value]) => {
+      Object.entries(spanAttributes ?? {}).forEach(([key, value]) => {
         span.setAttribute(key, value);
       });
 

--- a/tests/lib/eval-dataset.test.ts
+++ b/tests/lib/eval-dataset.test.ts
@@ -95,22 +95,22 @@ describe('evalDataset', () => {
     expect(mockEvalTest).toHaveBeenCalledTimes(3);
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 1',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 1' },
       inputs: { input: 1 },
+      spanAttributes: {},
       schema: InputSchema,
       callback: mockInteraction,
     });
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 2',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 2' },
       inputs: { input: 2 },
+      spanAttributes: {},
       schema: InputSchema,
       callback: mockInteraction,
     });
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 3',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 3' },
       inputs: { input: 3 },
+      spanAttributes: {},
       schema: InputSchema,
       callback: mockInteraction,
     });
@@ -128,8 +128,8 @@ describe('evalDataset', () => {
 
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Case 1',
-      spanAttributes: { 'gentrace.test_case_name': 'Case 1' },
       inputs: { input: 10 },
+      spanAttributes: {},
       schema: InputSchema,
       callback: mockInteraction,
     });
@@ -152,8 +152,8 @@ describe('evalDataset', () => {
 
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 4',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 4' },
       inputs: { input: 40 },
+      spanAttributes: {},
       schema: InputSchema,
       callback: mockInteraction,
     });
@@ -264,8 +264,8 @@ describe('evalDataset', () => {
     expect(mockEvalTest).toHaveBeenCalledTimes(1);
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 1',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 1' },
       inputs: { input: 5 },
+      spanAttributes: {},
       schema: CustomSchema, // Check that the custom schema object is passed
       callback: customInteraction,
     });
@@ -299,8 +299,8 @@ describe('evalDataset', () => {
     expect(mockEvalTest).toHaveBeenCalledTimes(1);
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case 1',
-      spanAttributes: { 'gentrace.test_case_name': 'Test Case 1' },
       inputs: { input: 99 },
+      spanAttributes: {},
       schema: FailingSchema, // The failing schema is passed
       callback: failingInteraction,
     });

--- a/tests/lib/eval-once.test.ts
+++ b/tests/lib/eval-once.test.ts
@@ -139,7 +139,6 @@ describe('evalOnce() function', () => {
       'gentrace.experiment_id',
       mockExperimentContext.experimentId,
     );
-    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.test_case_name', testName);
     expect(callback).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### TL;DR

Removed redundant `gentrace.test_case_name` span attribute

### What changed?

- Removed the automatic setting of `gentrace.test_case_name` span attribute in `eval-once.ts` and `eval-dataset.ts`
- Made the `spanAttributes` parameter optional in `RunEvalInternalOptions` interface
- Updated the `_runEval` function to handle potentially undefined `spanAttributes`
- Updated all relevant tests to reflect these changes

### How to test?

1. Run the existing test suite to ensure all tests pass
2. Verify that test spans are still created correctly but without the redundant `gentrace.test_case_name` attribute
3. Confirm that test cases with explicit IDs still have the `gentrace.test_case_id` attribute set

### Why make this change?

This change streamlines the telemetry data by removing redundant span attributes. The `gentrace.test_case_name` attribute was duplicating information already available in the span name itself, making it unnecessary. This simplification makes the telemetry data cleaner and more efficient while maintaining all essential information for tracking and analysis.