### PR TITLE
chore: Rename to evalOnce() and evalDataset()

### DIFF
--- a/examples/eval-dataset.ts
+++ b/examples/eval-dataset.ts
@@ -7,7 +7,7 @@ import { readEnv } from 'gentrace/internal/utils';
 import { experiment } from 'gentrace/lib/experiment';
 import { init, testCases } from 'gentrace/lib/init';
 import { interaction } from 'gentrace/lib/interaction';
-import { testDataset } from 'gentrace/lib/test-dataset';
+import { evalDataset } from 'gentrace/lib/eval-dataset';
 import { z } from 'zod';
 import { queryAi } from './functions/query';
 
@@ -62,7 +62,7 @@ const InputSchema = z.object({
 const queryAiInteraction = interaction(GENTRACE_PIPELINE_ID, queryAi);
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
-  await testDataset({
+  await evalDataset({
     data: async () => {
       const testCasesList = await testCases.list({ datasetId: GENTRACE_DATASET_ID });
       return testCasesList.data;

--- a/examples/eval-once.ts
+++ b/examples/eval-once.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { init, experiment, test } from '../src';
+import { init, experiment, evalOnce } from '../src';
 import { readEnv } from 'gentrace/internal/utils';
 
 dotenv.config();
@@ -11,7 +11,7 @@ init({
 const PIPELINE_ID = readEnv('GENTRACE_PIPELINE_ID')!;
 
 experiment(PIPELINE_ID, async () => {
-  test('simple-addition-test', () => {
+  evalOnce('simple-addition-test', () => {
     return 1 + 1;
   });
 });

--- a/examples/no-params.ts
+++ b/examples/no-params.ts
@@ -7,7 +7,7 @@ import { readEnv } from 'gentrace/internal/utils';
 import { experiment } from 'gentrace/lib/experiment';
 import { init } from 'gentrace/lib/init';
 import { interaction } from 'gentrace/lib/interaction';
-import { test } from 'gentrace/lib/test-single';
+import { evalOnce } from 'gentrace/lib/eval-once';
 
 dotenv.config();
 
@@ -56,7 +56,7 @@ const simpleTask = () => {
 const simpleInteraction = interaction(GENTRACE_PIPELINE_ID, simpleTask);
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
-  await test('No Params Test Case', async () => {
+  await evalOnce('No Params Test Case', async () => {
     return await simpleInteraction();
   });
 });

--- a/examples/openai-composition.ts
+++ b/examples/openai-composition.ts
@@ -72,6 +72,7 @@ if (process.env['ENVIRONMENT'] === 'production') {
   spanProcessors = [
     new GentraceSpanProcessor(),
     new SimpleSpanProcessor(traceExporter),
+
     new SimpleSpanProcessor(new ConsoleSpanExporter()),
   ];
 

--- a/examples/test-openai-composition.ts
+++ b/examples/test-openai-composition.ts
@@ -7,7 +7,7 @@ import { readEnv } from 'gentrace/internal/utils';
 import { experiment } from '../src/lib/experiment';
 import { init } from '../src/lib/init';
 import { interaction } from '../src/lib/interaction';
-import { test } from '../src/lib/test-single';
+import { evalOnce } from '../src/lib/eval-once';
 import { composeEmail } from './functions/composition';
 
 const GENTRACE_BASE_URL = readEnv('GENTRACE_BASE_URL');
@@ -54,7 +54,7 @@ process.on('SIGTERM', async () => {
 const compose = interaction(GENTRACE_PIPELINE_ID, composeEmail);
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
-  await test('Simplified Test Case', async () => {
+  await evalOnce('Simplified Test Case', async () => {
     return await compose('TestRecipient', 'TestTopic', 'TestSender');
   });
 });

--- a/src/lib/eval-once.ts
+++ b/src/lib/eval-once.ts
@@ -1,7 +1,7 @@
 import { Span, SpanStatusCode, trace } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
 import { getCurrentExperimentContext } from './experiment'; // Assuming this provides the experimentId
-import { ParseableSchema } from './test-dataset'; // Import the interface
+import { ParseableSchema } from './eval-dataset'; // Import the interface
 import { _getClient } from './client-instance';
 
 /**
@@ -17,16 +17,16 @@ import { _getClient } from './client-instance';
  *
  * @example
  * experiment('pipeline-uuid', () => {
- *   test('simple-addition-test', () => {
+ *   evalOnce('simple-addition-test', () => {
  *     return 1 + 1;
  *   });
  * });
  */
-export async function test<TResult>(
+export async function evalOnce<TResult>(
   spanName: string,
   callback: () => TResult | null | Promise<TResult | null>,
 ): Promise<TResult | null> {
-  return _runTest<TResult, any>({
+  return _runEval<TResult, any>({
     spanName,
     spanAttributes: { 'gentrace.test_case_name': spanName },
     callback,
@@ -36,12 +36,12 @@ export async function test<TResult>(
 /**
  * Metadata for a specific test run.
  */
-export type TestMetadata = Record<string, unknown>;
+export type EvalMetadata = Record<string, unknown>;
 
 /**
  * Input parameters for running a single test case.
  */
-export type RunTestParams<T> = {
+export type RunEvalParams<T> = {
   /** The descriptive name of the test case (like an 'it' block name). */
   name: string;
   /** The function containing the test logic. Can be sync or async. */
@@ -49,12 +49,12 @@ export type RunTestParams<T> = {
 };
 
 /**
- * Options for the internal _runTest function.
+ * Options for the internal _runEval function.
  *
- * @template TResult The expected return type of the test callback.
- * @template TInput The expected input type of the test callback (after potential parsing).
+ * @template TResult The expected return type of the eval callback.
+ * @template TInput The expected input type of the eval callback (after potential parsing).
  */
-export type RunTestInternalOptions<TResult, TInput> = {
+export type RunEvalInternalOptions<TResult, TInput> = {
   spanName: string;
   spanAttributes: Record<string, string>;
   inputs?: unknown | undefined;
@@ -73,8 +73,8 @@ export type RunTestInternalOptions<TResult, TInput> = {
  * @returns The result of the callback function.
  * @throws If called outside of a `experiment()` context or if the callback throws.
  */
-export async function _runTest<TResult, TInput = any>(
-  options: RunTestInternalOptions<TResult, TInput>, // Single options parameter
+export async function _runEval<TResult, TInput = any>(
+  options: RunEvalInternalOptions<TResult, TInput>, // Single options parameter
 ): Promise<TResult | null> {
   const { spanName, spanAttributes, inputs, schema, callback } = options;
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,7 +7,7 @@ export {
   FinishExperimentParams,
 } from './experiment-control';
 export { interaction } from './interaction';
-export { testDataset } from './test-dataset';
+export { evalDataset as evalDataset } from './eval-dataset';
 export { traced } from './traced';
-export { test } from './test-single';
+export { evalOnce } from './eval-once';
 export * from './otel';

--- a/tests/lib/eval-once.test.ts
+++ b/tests/lib/eval-once.test.ts
@@ -34,11 +34,11 @@ const mockGentraceClient = {
   },
 };
 
-describe('test() function', () => {
+describe('evalOnce() function', () => {
   const mockExperimentContext = { experimentId: 'exp-test-123', pipelineId: 'pipe-test-456' };
 
   let api: typeof import('@opentelemetry/api');
-  let testLib: typeof import('../../src/lib/test-single');
+  let evalOnceLib: typeof import('../../src/lib/eval-once');
   let mockedStartActiveSpan: jest.Mock;
   let getStoreSpy: jest.SpiedFunction<any>;
 
@@ -62,7 +62,7 @@ describe('test() function', () => {
       }));
 
       api = require('@opentelemetry/api');
-      testLib = require('../../src/lib/test-single');
+      evalOnceLib = require('../../src/lib/eval-once');
       const { experimentContextStorage } = require('gentrace/lib/experiment');
 
       jest.clearAllMocks();
@@ -118,7 +118,7 @@ describe('test() function', () => {
     const testName = 'test outside context';
     const callback = jest.fn(async () => {});
 
-    await expect(testLib.test(testName, callback)).rejects.toThrow(
+    await expect(evalOnceLib.evalOnce(testName, callback)).rejects.toThrow(
       `${testName} must be called within the context of an experiment() function.`,
     );
 
@@ -130,7 +130,7 @@ describe('test() function', () => {
     const testName = 'My Test Name';
     const callback = jest.fn(async () => 'result');
 
-    await testLib.test(testName, callback);
+    await evalOnceLib.evalOnce(testName, callback);
 
     expect(mockedStartActiveSpan).toHaveBeenCalledTimes(1);
     expect(mockedStartActiveSpan).toHaveBeenCalledWith(testName, expect.any(Function));
@@ -148,7 +148,7 @@ describe('test() function', () => {
     const expectedResult = 'async success';
     const callback = jest.fn(async () => expectedResult);
 
-    const result = await testLib.test(testName, callback);
+    const result = await evalOnceLib.evalOnce(testName, callback);
 
     expect(result).toBe(expectedResult);
     expect(callback).toHaveBeenCalledTimes(1);
@@ -168,7 +168,7 @@ describe('test() function', () => {
       throw error;
     });
 
-    const result = await testLib.test(testName, callback);
+    const result = await evalOnceLib.evalOnce(testName, callback);
     expect(result).toBeNull();
 
     expect(callback).toHaveBeenCalledTimes(1);
@@ -186,7 +186,7 @@ describe('test() function', () => {
     const expectedResult = 'sync success';
     const callback = jest.fn(() => expectedResult);
 
-    const result = await testLib.test(testName, callback);
+    const result = await evalOnceLib.evalOnce(testName, callback);
 
     expect(result).toBe(expectedResult);
     expect(callback).toHaveBeenCalledTimes(1);
@@ -205,7 +205,7 @@ describe('test() function', () => {
       throw error;
     });
 
-    await testLib.test(testName, callback);
+    await evalOnceLib.evalOnce(testName, callback);
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(lastMockSpan?.recordException).toHaveBeenCalledWith(error);


### PR DESCRIPTION
### TL;DR

Renamed test functions to eval functions to better reflect their purpose in evaluating AI systems. Makes the interface similar to Python.

### What changed?

- Renamed `test` to `evalOnce` for single evaluations
- Renamed `testDataset` to `evalDataset` for dataset-based evaluations
- Updated all imports, function calls, and documentation to reflect these changes
- Renamed related files:
  - `test-single.ts` → `eval-once.ts`
  - `test-dataset.ts` → `eval-dataset.ts`
  - `test-dataset.test.ts` → `eval-dataset.test.ts`
  - `test-single.test.ts` → `eval-once.test.ts`
- Updated example files to use the new function names
- Updated README.md to reflect the new terminology

### How to test?

1. Run the updated examples to verify they work with the new function names:
   ```
   GENTRACE_PIPELINE_ID=<your-pipeline-id> GENTRACE_API_KEY=<your-api-key> npx ts-node examples/eval-once.ts
   GENTRACE_PIPELINE_ID=<your-pipeline-id> GENTRACE_API_KEY=<your-api-key> npx ts-node examples/eval-dataset.ts
   ```

2. Verify that all tests pass with the updated function names:
   ```
   npm test
   ```

### Why make this change?

The term "eval" more accurately describes the purpose of these functions in the context of AI systems evaluation. This change aligns the function names with their actual purpose - evaluating AI system performance rather than traditional software testing. This makes the API more intuitive and clearer for users working with AI evaluation workflows.