### PR TITLE
fix: Refactor attributes into constants

### DIFF
--- a/src/lib/eval-dataset.ts
+++ b/src/lib/eval-dataset.ts
@@ -1,6 +1,7 @@
 import { _getClient } from './client-instance';
 import { getCurrentExperimentContext } from './experiment';
 import { _runEval } from './eval-once';
+import { ATTR_GENTRACE_TEST_CASE_ID } from './otel/constants';
 
 /**
  * Runs a series of evals  against a dataset using a provided interaction function.
@@ -85,7 +86,7 @@ export async function evalDataset<
 
     const spanAttributes: Record<string, string> = {};
     if (typeof finalId === 'string') {
-      spanAttributes['gentrace.test_case_id'] = finalId;
+      spanAttributes[ATTR_GENTRACE_TEST_CASE_ID] = finalId;
     }
 
     promises.push(

--- a/src/lib/eval-once.ts
+++ b/src/lib/eval-once.ts
@@ -3,6 +3,11 @@ import stringify from 'json-stringify-safe';
 import { getCurrentExperimentContext } from './experiment'; // Assuming this provides the experimentId
 import { ParseableSchema } from './eval-dataset'; // Import the interface
 import { _getClient } from './client-instance';
+import {
+  ATTR_GENTRACE_EXPERIMENT_ID,
+  ATTR_GENTRACE_FN_ARGS,
+  ATTR_GENTRACE_FN_OUTPUT,
+} from './otel/constants';
 
 /**
  * Runs a single named test case within the context of an active experiment.
@@ -88,7 +93,7 @@ export async function _runEval<TResult, TInput = any>(
 
   return new Promise<TResult | null>((resolve) => {
     tracer.startActiveSpan(spanName, async (span: Span) => {
-      span.setAttribute('gentrace.experiment_id', experimentId);
+      span.setAttribute(ATTR_GENTRACE_EXPERIMENT_ID, experimentId);
       Object.entries(spanAttributes ?? {}).forEach(([key, value]) => {
         span.setAttribute(key, value);
       });
@@ -109,7 +114,7 @@ export async function _runEval<TResult, TInput = any>(
         }
 
         if (parsedInputs) {
-          span.addEvent('gentrace.fn.args', {
+          span.addEvent(ATTR_GENTRACE_FN_ARGS, {
             args: stringify([parsedInputs]),
           });
         }
@@ -119,7 +124,7 @@ export async function _runEval<TResult, TInput = any>(
         if (result instanceof Promise) {
           result.then(
             (resolvedResult) => {
-              span.addEvent('gentrace.fn.output', {
+              span.addEvent(ATTR_GENTRACE_FN_OUTPUT, {
                 output: stringify(resolvedResult),
               });
               span.end();
@@ -137,7 +142,7 @@ export async function _runEval<TResult, TInput = any>(
             },
           );
         } else {
-          span.addEvent('gentrace.fn.output', {
+          span.addEvent(ATTR_GENTRACE_FN_OUTPUT, {
             output: stringify(result),
           });
           span.end();

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -1,5 +1,7 @@
 import { context, propagation } from '@opentelemetry/api';
 import { ANONYMOUS_SPAN_NAME } from './constants';
+
+import { ATTR_GENTRACE_PIPELINE_ID, ATTR_GENTRACE_SAMPLE } from './otel/constants';
 import { TracedOptions, traced } from './traced';
 
 /**
@@ -19,7 +21,7 @@ export function interaction<F extends (...args: any[]) => any>(
   options: TracedOptions = {
     name: fn.name || ANONYMOUS_SPAN_NAME,
     attributes: {
-      'gentrace.pipeline_id': pipelineId,
+      [ATTR_GENTRACE_PIPELINE_ID]: pipelineId,
     },
   },
 ): F {
@@ -30,7 +32,7 @@ export function interaction<F extends (...args: any[]) => any>(
     name: interactionName,
     attributes: {
       ...options.attributes,
-      'gentrace.pipeline_id': pipelineId,
+      [ATTR_GENTRACE_PIPELINE_ID]: pipelineId,
     },
   });
 
@@ -38,7 +40,7 @@ export function interaction<F extends (...args: any[]) => any>(
     const currentContext = context.active();
     const currentBaggage = propagation.getBaggage(currentContext) ?? propagation.createBaggage();
 
-    const newBaggage = currentBaggage.setEntry('gentrace.sample', {
+    const newBaggage = currentBaggage.setEntry(ATTR_GENTRACE_SAMPLE, {
       value: 'true',
     });
     const newContext = propagation.setBaggage(currentContext, newBaggage);

--- a/src/lib/otel/constants.ts
+++ b/src/lib/otel/constants.ts
@@ -2,4 +2,34 @@
  * Key used to identify Gentrace sampling configuration in baggage and span attributes.
  * When set to 'true', indicates that the span should be sampled.
  */
-export const GENTRACE_SAMPLE_KEY = 'gentrace.sample';
+export const ATTR_GENTRACE_SAMPLE = 'gentrace.sample';
+
+/**
+ * Key used to identify which Gentrace pipeline a particular span belongs to.
+ * Spans tagged with this attribute will be viewable in the "Traces" section of the Gentrace dashboard.
+ */
+export const ATTR_GENTRACE_PIPELINE_ID = 'gentrace.pipeline_id';
+
+/**
+ * Key used to identify which Gentrace test case a particular span belongs to.
+ * This attribute links spans to their associated test case in a dataset in Gentrace.
+ */
+export const ATTR_GENTRACE_TEST_CASE_ID = 'gentrace.test_case_id';
+
+/**
+ * Key used to identify which Gentrace experiment a test span(s) invoked with evalOnce
+ * or testDataset belongs to.
+ */
+export const ATTR_GENTRACE_EXPERIMENT_ID = 'gentrace.experiment_id';
+
+/**
+ * Key used to identify the function arguments event in Gentrace spans.
+ * This event attribute captures the serialized input arguments passed to traced functions.
+ */
+export const ATTR_GENTRACE_FN_ARGS = 'gentrace.fn.args';
+
+/**
+ * Key used to identify the function output event in Gentrace spans.
+ * This event attribute captures the serialized return value of traced functions.
+ */
+export const ATTR_GENTRACE_FN_OUTPUT = 'gentrace.fn.output';

--- a/src/lib/otel/index.ts
+++ b/src/lib/otel/index.ts
@@ -1,3 +1,3 @@
 export { GentraceSpanProcessor } from './span-processor';
 export { GentraceSampler } from './sampler';
-export { GENTRACE_SAMPLE_KEY } from './constants';
+export { ATTR_GENTRACE_SAMPLE as GENTRACE_SAMPLE_KEY } from './constants';

--- a/src/lib/otel/sampler.ts
+++ b/src/lib/otel/sampler.ts
@@ -1,7 +1,7 @@
 import { Context, propagation } from '@opentelemetry/api';
 import { Sampler, SamplingDecision, SamplingResult } from '@opentelemetry/sdk-trace-base';
 import { Attributes, Link, SpanKind } from '@opentelemetry/api';
-import { GENTRACE_SAMPLE_KEY } from './constants';
+import { ATTR_GENTRACE_SAMPLE } from './constants';
 
 /**
  * A sampler that samples spans based on the presence of a 'gentrace.sample' baggage entry
@@ -29,11 +29,11 @@ export class GentraceSampler implements Sampler {
     links: Link[],
   ): SamplingResult {
     const currentMomentBaggage = propagation.getBaggage(context);
-    const sampleEntry = currentMomentBaggage?.getEntry(GENTRACE_SAMPLE_KEY);
+    const sampleEntry = currentMomentBaggage?.getEntry(ATTR_GENTRACE_SAMPLE);
 
     if (
       (currentMomentBaggage && sampleEntry?.value === 'true') ||
-      attributes[GENTRACE_SAMPLE_KEY] === 'true'
+      attributes[ATTR_GENTRACE_SAMPLE] === 'true'
     ) {
       return { decision: SamplingDecision.RECORD_AND_SAMPLED };
     } else {

--- a/src/lib/otel/span-processor.ts
+++ b/src/lib/otel/span-processor.ts
@@ -1,6 +1,6 @@
 import { Context, propagation } from '@opentelemetry/api';
 import { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { GENTRACE_SAMPLE_KEY } from './constants';
+import { ATTR_GENTRACE_SAMPLE } from './constants';
 
 /**
  * A function that determines whether a baggage key-value pair should be added to new
@@ -32,7 +32,7 @@ export class GentraceSpanProcessor implements SpanProcessor {
    */
   onStart(span: Span, parentContext: Context): void {
     (propagation.getBaggage(parentContext)?.getAllEntries() ?? [])
-      .filter((entry) => entry[0] === GENTRACE_SAMPLE_KEY)
+      .filter((entry) => entry[0] === ATTR_GENTRACE_SAMPLE)
       .forEach((entry) => span.setAttribute(entry[0], entry[1].value));
   }
 

--- a/src/lib/traced.ts
+++ b/src/lib/traced.ts
@@ -1,6 +1,7 @@
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
 import { ANONYMOUS_SPAN_NAME } from './constants';
+import { ATTR_GENTRACE_FN_ARGS, ATTR_GENTRACE_FN_OUTPUT } from './otel/constants';
 
 /**
  * Options for configuring the behavior of the traced function.
@@ -47,7 +48,7 @@ export function traced<F extends (...args: any[]) => any>(
 
       try {
         const argsString = stringify(args);
-        span.addEvent('gentrace.fn.args', { args: argsString });
+        span.addEvent(ATTR_GENTRACE_FN_ARGS, { args: argsString });
 
         const result = fn(...args);
 
@@ -55,7 +56,7 @@ export function traced<F extends (...args: any[]) => any>(
           return result
             .then((finalOutput) => {
               const outputString = stringify(finalOutput);
-              span.addEvent('gentrace.fn.output', { output: outputString });
+              span.addEvent(ATTR_GENTRACE_FN_OUTPUT, { output: outputString });
               span.end();
               return finalOutput;
             })
@@ -68,7 +69,7 @@ export function traced<F extends (...args: any[]) => any>(
             });
         } else {
           const outputString = stringify(result);
-          span.addEvent('gentrace.fn.output', { output: outputString });
+          span.addEvent(ATTR_GENTRACE_FN_OUTPUT, { output: outputString });
           span.end();
           return result;
         }

--- a/tests/lib/eval-dataset.test.ts
+++ b/tests/lib/eval-dataset.test.ts
@@ -1,5 +1,6 @@
 import { TestInput } from '../../src/lib/eval-dataset';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ATTR_GENTRACE_TEST_CASE_ID } from 'gentrace/lib/otel/constants';
 import { z } from 'zod';
 
 const mockGentraceClient: {
@@ -136,7 +137,7 @@ describe('evalDataset', () => {
 
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Test Case (ID: case-id-20)',
-      spanAttributes: { 'gentrace.test_case_id': 'case-id-20' },
+      spanAttributes: { [ATTR_GENTRACE_TEST_CASE_ID]: 'case-id-20' },
       inputs: { input: 20 },
       schema: InputSchema,
       callback: mockInteraction,
@@ -144,7 +145,7 @@ describe('evalDataset', () => {
 
     expect(mockEvalTest).toHaveBeenCalledWith({
       spanName: 'Case 30',
-      spanAttributes: { 'gentrace.test_case_id': 'case-id-30' },
+      spanAttributes: { [ATTR_GENTRACE_TEST_CASE_ID]: 'case-id-30' },
       inputs: { input: 30 },
       schema: InputSchema,
       callback: mockInteraction,

--- a/tests/lib/eval-once.test.ts
+++ b/tests/lib/eval-once.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import type { Span } from '@opentelemetry/api';
 import { init } from 'gentrace/lib/init';
+import { ATTR_GENTRACE_EXPERIMENT_ID, ATTR_GENTRACE_FN_OUTPUT } from 'gentrace/lib/otel/constants';
 import stringify from 'json-stringify-safe';
 
 let lastMockSpan: Partial<Span> | null = null;
@@ -86,7 +87,7 @@ describe('evalOnce() function', () => {
 
         try {
           const result = await fn(mockSpan as unknown as Span);
-          mockSpan.addEvent('gentrace.fn.output', { output: stringify(result) });
+          mockSpan.addEvent(ATTR_GENTRACE_FN_OUTPUT, { output: stringify(result) });
           return result;
         } catch (error: any) {
           mockSpan.recordException(error);
@@ -136,7 +137,7 @@ describe('evalOnce() function', () => {
     expect(mockedStartActiveSpan).toHaveBeenCalledWith(testName, expect.any(Function));
 
     expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(
-      'gentrace.experiment_id',
+      ATTR_GENTRACE_EXPERIMENT_ID,
       mockExperimentContext.experimentId,
     );
     expect(callback).toHaveBeenCalledTimes(1);
@@ -152,7 +153,7 @@ describe('evalOnce() function', () => {
     expect(result).toBe(expectedResult);
     expect(callback).toHaveBeenCalledTimes(1);
 
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
       output: stringify(expectedResult),
     });
     expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();
@@ -189,7 +190,7 @@ describe('evalOnce() function', () => {
 
     expect(result).toBe(expectedResult);
     expect(callback).toHaveBeenCalledTimes(1);
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
       output: stringify(expectedResult),
     });
     expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();

--- a/tests/lib/interaction.test.ts
+++ b/tests/lib/interaction.test.ts
@@ -3,6 +3,11 @@ import { Span, SpanStatusCode } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
 import { ANONYMOUS_SPAN_NAME } from 'gentrace/lib/constants';
 import { TracedOptions } from 'gentrace/lib/traced';
+import {
+  ATTR_GENTRACE_FN_ARGS,
+  ATTR_GENTRACE_FN_OUTPUT,
+  ATTR_GENTRACE_PIPELINE_ID,
+} from 'gentrace/lib/otel/constants';
 
 let lastMockSpan: Partial<Span> | null = null;
 
@@ -94,9 +99,11 @@ describe('interaction wrapper', () => {
     expect(mockStartActiveSpan).toHaveBeenCalledWith('originalFn', expect.any(Function));
 
     expect(lastMockSpan).not.toBeNull();
-    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([{ a: 5 }]) });
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', { output: stringify(10) });
+    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
+      args: stringify([{ a: 5 }]),
+    });
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, { output: stringify(10) });
     expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();
     expect(lastMockSpan?.end).toHaveBeenCalledTimes(2);
   });
@@ -115,11 +122,11 @@ describe('interaction wrapper', () => {
     expect(mockStartActiveSpan).toHaveBeenCalledWith('originalFn', expect.any(Function));
 
     expect(lastMockSpan).not.toBeNull();
-    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', {
+    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
       args: stringify([{ b: 'World' }]),
     });
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
       output: stringify('Hello World'),
     });
     expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();
@@ -139,8 +146,8 @@ describe('interaction wrapper', () => {
     expect(mockStartActiveSpan).toHaveBeenCalledTimes(1);
 
     expect(lastMockSpan).not.toBeNull();
-    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', {
+    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
       args: stringify([{ c: true }]),
     });
     expect(lastMockSpan?.recordException).toHaveBeenCalledWith(error);
@@ -165,8 +172,8 @@ describe('interaction wrapper', () => {
     expect(mockStartActiveSpan).toHaveBeenCalledTimes(1);
 
     expect(lastMockSpan).not.toBeNull();
-    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', {
+    expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
       args: stringify([{ d: [1, 2] }]),
     });
     expect(lastMockSpan?.recordException).toHaveBeenCalledWith(error);
@@ -204,10 +211,10 @@ describe('interaction wrapper', () => {
     const wrappedFn = interaction(pipelineId, originalFn);
     wrappedFn(complexArg);
 
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', {
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
       args: stringify([complexArg]),
     });
-    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+    expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
       output: stringify(complexOutput),
     });
   });
@@ -223,9 +230,9 @@ describe('interaction wrapper', () => {
       expect(mockStartActiveSpan).toHaveBeenCalledWith(syncNoParamsFn.name, expect.any(Function));
 
       expect(lastMockSpan).not.toBeNull();
-      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
         output: stringify('sync success'),
       });
       expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();
@@ -245,9 +252,9 @@ describe('interaction wrapper', () => {
       expect(mockStartActiveSpan).toHaveBeenCalledWith(asyncNoParamsFn.name, expect.any(Function));
 
       expect(lastMockSpan).not.toBeNull();
-      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
         output: stringify('async success'),
       });
       expect(lastMockSpan?.setStatus).not.toHaveBeenCalled();
@@ -266,8 +273,8 @@ describe('interaction wrapper', () => {
       expect(mockStartActiveSpan).toHaveBeenCalledWith(syncErrorFn.name, expect.any(Function));
 
       expect(lastMockSpan).not.toBeNull();
-      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
+      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
       expect(lastMockSpan?.recordException).toHaveBeenCalledWith(error);
       expect(lastMockSpan?.setStatus).toHaveBeenCalledWith({
         code: SpanStatusCode.ERROR,
@@ -290,8 +297,8 @@ describe('interaction wrapper', () => {
       expect(mockStartActiveSpan).toHaveBeenCalledWith(asyncRejectFn.name, expect.any(Function));
 
       expect(lastMockSpan).not.toBeNull();
-      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith('gentrace.pipeline_id', pipelineId);
-      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
+      expect(lastMockSpan?.setAttribute).toHaveBeenCalledWith(ATTR_GENTRACE_PIPELINE_ID, pipelineId);
+      expect(lastMockSpan?.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
       expect(lastMockSpan?.recordException).toHaveBeenCalledWith(error);
       expect(lastMockSpan?.setStatus).toHaveBeenCalledWith({
         code: SpanStatusCode.ERROR,

--- a/tests/lib/traced.test.ts
+++ b/tests/lib/traced.test.ts
@@ -2,6 +2,7 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
 import { ANONYMOUS_SPAN_NAME } from '../../src/lib/constants';
 import { traced } from '../../src/lib/traced';
+import { ATTR_GENTRACE_FN_ARGS, ATTR_GENTRACE_FN_OUTPUT } from 'gentrace/lib/otel/constants';
 
 // Mock OpenTelemetry API
 const mockSpan = {
@@ -76,8 +77,8 @@ describe('traced decorator', () => {
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
     expect(mockTracer.startActiveSpan).toHaveBeenCalledWith('syncAdd', expect.any(Function));
     expect(mockSpan.addEvent).toHaveBeenCalledTimes(2);
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([2, 3]) });
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.output', { output: stringify(5) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([2, 3]) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, { output: stringify(5) });
     expect(mockSpan.recordException).not.toHaveBeenCalled();
     expect(mockSpan.setStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ code: SpanStatusCode.ERROR }),
@@ -97,8 +98,8 @@ describe('traced decorator', () => {
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
     expect(mockTracer.startActiveSpan).toHaveBeenCalledWith('asyncMultiply', expect.any(Function));
     expect(mockSpan.addEvent).toHaveBeenCalledTimes(2);
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([4, 5]) });
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.output', { output: stringify(20) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([4, 5]) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, { output: stringify(20) });
     expect(mockSpan.recordException).not.toHaveBeenCalled();
     expect(mockSpan.setStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ code: SpanStatusCode.ERROR }),
@@ -118,7 +119,7 @@ describe('traced decorator', () => {
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
     expect(mockTracer.startActiveSpan).toHaveBeenCalledWith('syncError', expect.any(Function));
     expect(mockSpan.addEvent).toHaveBeenCalledTimes(1); // Only args event
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
     expect(mockSpan.recordException).toHaveBeenCalledTimes(1);
     expect(mockSpan.recordException).toHaveBeenCalledWith(expect.any(Error));
     expect(mockSpan.setStatus).toHaveBeenCalledTimes(1);
@@ -139,7 +140,7 @@ describe('traced decorator', () => {
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
     expect(mockTracer.startActiveSpan).toHaveBeenCalledWith('asyncReject', expect.any(Function));
     expect(mockSpan.addEvent).toHaveBeenCalledTimes(1); // Only args event
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([]) });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, { args: stringify([]) });
     expect(mockSpan.recordException).toHaveBeenCalledTimes(1);
     expect(mockSpan.recordException).toHaveBeenCalledWith(expect.any(Error));
     expect(mockSpan.setStatus).toHaveBeenCalledTimes(1);
@@ -201,8 +202,10 @@ describe('traced decorator', () => {
     // Function name might be empty string or specific depending on env, check default
     expect(mockTracer.startActiveSpan).toHaveBeenCalledWith(ANONYMOUS_SPAN_NAME, expect.any(Function));
     expect(mockSpan.addEvent).toHaveBeenCalledTimes(2);
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.args', { args: stringify([argObj, argArr]) });
-    expect(mockSpan.addEvent).toHaveBeenCalledWith('gentrace.fn.output', {
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_ARGS, {
+      args: stringify([argObj, argArr]),
+    });
+    expect(mockSpan.addEvent).toHaveBeenCalledWith(ATTR_GENTRACE_FN_OUTPUT, {
       output: stringify(expectedResult),
     });
     expect(mockSpan.end).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### TL;DR

Refactored OpenTelemetry attribute keys into constants for better maintainability and consistency.

### What changed?

- Created and consolidated OpenTelemetry attribute keys as named constants in `src/lib/otel/constants.ts`
- Renamed `GENTRACE_SAMPLE_KEY` to `ATTR_GENTRACE_SAMPLE` for consistency
- Added new constants for various Gentrace attributes:
  - `ATTR_GENTRACE_PIPELINE_ID`
  - `ATTR_GENTRACE_TEST_CASE_ID`
  - `ATTR_GENTRACE_EXPERIMENT_ID`
  - `ATTR_GENTRACE_FN_ARGS`
  - `ATTR_GENTRACE_FN_OUTPUT`
- Updated all references to hardcoded string literals throughout the codebase to use these constants
- Updated tests to use the new constants

### How to test?

1. Run the existing test suite to ensure all functionality works as expected
2. Verify that tracing still works correctly in applications using the library
3. Check that spans are properly tagged with the correct attributes in the Gentrace dashboard

### Why make this change?

- Improves code maintainability by centralizing attribute key definitions
- Reduces the risk of typos when using attribute keys
- Makes it easier to update attribute keys in the future if needed
- Follows best practices for string constants in TypeScript
- Provides better documentation through JSDoc comments for each constant