### PR TITLE
chore: Add interaction name for simplicity

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -14,16 +14,16 @@ jobs:
   claude-response:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          
+
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ The API reference documentation, auto-generated from our Stainless client code, 
 ## Installation
 
 ```sh
-# OR yarn add/pnpm install
-npm install gentrace
+yarn add gentrace
 ```
 
 ## Core Concepts
@@ -84,8 +83,11 @@ async function queryAi({ query }: { query: string }): Promise<string | null> {
 
 // Create an instrumented version of the function
 export const instrumentedQueryAi = interaction(
-  GENTRACE_PIPELINE_ID,
-  queryAi // Pass the original function
+  'Query AI', // Explicitly set the name of the interaction
+  queryAi, // Pass the original function
+  {
+    pipelineId: GENTRACE_PIPELINE_ID,
+  }
 );
 
 // Example of calling the instrumented function
@@ -221,8 +223,7 @@ OpenTelemetry integration is **required** for the Gentrace SDK's instrumentation
 <summary>Click here to view the command for installing OpenTelemetry peer dependencies manually</summary>
 
 ```sh
-# OR use yarn or pnpm
-npm i @opentelemetry/api@^1.9.0 @opentelemetry/context-async-hooks@^2.0.0 @opentelemetry/core@^2.0.0 @opentelemetry/exporter-trace-otlp-http@^0.200.0 @opentelemetry/resources@^2.0.0 @opentelemetry/sdk-node@^0.200.0 @opentelemetry/sdk-trace-node@^2.0.0 @opentelemetry/semantic-conventions@^1.25.0 @opentelemetry/baggage-span-processor@^0.4.0
+yarn add @opentelemetry/api@^1.9.0 @opentelemetry/context-async-hooks@^2.0.0 @opentelemetry/core@^2.0.0 @opentelemetry/exporter-trace-otlp-http@^0.200.0 @opentelemetry/resources@^2.0.0 @opentelemetry/sdk-node@^0.200.0 @opentelemetry/sdk-trace-node@^2.0.0 @opentelemetry/semantic-conventions@^1.25.0 @opentelemetry/baggage-span-processor@^0.4.0
 ```
 
 </details>

--- a/examples/eval-dataset.ts
+++ b/examples/eval-dataset.ts
@@ -59,7 +59,9 @@ const InputSchema = z.object({
   query: z.string(),
 });
 
-const queryAiInteraction = interaction(GENTRACE_PIPELINE_ID, queryAi);
+const queryAiInteraction = interaction('Query AI', queryAi, {
+  pipelineId: GENTRACE_PIPELINE_ID,
+});
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   await evalDataset({

--- a/examples/functions/composition.ts
+++ b/examples/functions/composition.ts
@@ -136,4 +136,4 @@ async function _composeEmailLogic(recipient: string, topic: string, sender: stri
   });
 }
 
-export const composeEmail = traced(_composeEmailLogic, { name: 'composeEmail' });
+export const composeEmail = traced('composeEmail', _composeEmailLogic);

--- a/examples/no-params.ts
+++ b/examples/no-params.ts
@@ -53,7 +53,9 @@ const simpleTask = () => {
   return 'Simple task completed!';
 };
 
-const simpleInteraction = interaction(GENTRACE_PIPELINE_ID, simpleTask);
+const simpleInteraction = interaction('Simple Interaction', simpleTask, {
+  pipelineId: GENTRACE_PIPELINE_ID,
+});
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   await evalOnce('No Params Test Case', async () => {

--- a/examples/openai-composition.ts
+++ b/examples/openai-composition.ts
@@ -108,7 +108,9 @@ process.on('SIGTERM', async () => {
 });
 // End OpenTelemetry SDK setup
 
-const compose = interaction(GENTRACE_PIPELINE_ID, composeEmail);
+const compose = interaction('Compose Email', composeEmail, {
+  pipelineId: GENTRACE_PIPELINE_ID,
+});
 
 async function main() {
   const draft = await compose('Alice', 'Project Phoenix Update', 'John Doe');

--- a/examples/test-openai-composition.ts
+++ b/examples/test-openai-composition.ts
@@ -51,7 +51,9 @@ process.on('SIGTERM', async () => {
 });
 // End OpenTelemetry SDK setup
 
-const compose = interaction(GENTRACE_PIPELINE_ID, composeEmail);
+const compose = interaction('Compose Email', composeEmail, {
+  pipelineId: GENTRACE_PIPELINE_ID,
+});
 
 experiment(GENTRACE_PIPELINE_ID, async () => {
   await evalOnce('Simplified Test Case', async () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,0 @@
-/**
- * The default name for anonymous functions.
- */
-export const ANONYMOUS_SPAN_NAME = 'anonymous';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,7 +6,7 @@ export {
   StartExperimentParams,
   FinishExperimentParams,
 } from './experiment-control';
-export { interaction } from './interaction';
+export { interaction, InteractionOptions } from './interaction';
 export { evalDataset as evalDataset } from './eval-dataset';
 export { traced } from './traced';
 export { evalOnce } from './eval-once';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,6 @@ export {
 } from './experiment-control';
 export { interaction, InteractionOptions } from './interaction';
 export { evalDataset as evalDataset } from './eval-dataset';
-export { traced } from './traced';
+export { traced, TracedConfig } from './traced';
 export { evalOnce } from './eval-once';
 export * from './otel';

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -1,8 +1,22 @@
 import { context, propagation } from '@opentelemetry/api';
-import { ANONYMOUS_SPAN_NAME } from './constants';
 
 import { ATTR_GENTRACE_PIPELINE_ID, ATTR_GENTRACE_SAMPLE } from './otel/constants';
-import { TracedOptions, traced } from './traced';
+import { traced } from './traced';
+
+/**
+ * Options for configuring the interaction function.
+ */
+export type InteractionOptions = {
+  /**
+   * The ID of the pipeline this interaction belongs to.
+   */
+  pipelineId: string;
+
+  /**
+   * Additional attributes to set on the span.
+   */
+  attributes?: Record<string, any>;
+};
 
 /**
  * Wraps a function with OpenTelemetry tracing to track interactions within a pipeline.
@@ -10,28 +24,22 @@ import { TracedOptions, traced } from './traced';
  * Handles functions that take either zero arguments or one argument which is a record.
  * Preserves the exact type signature (including sync/async return type) of the original function.
  *
- * @param pipelineId The ID of the pipeline this interaction belongs to.
+ * @param name The name for the span.
  * @param fn The function to wrap. Must take zero args or a single record argument.
- * @param options Optional span-specific options.
+ * @param options Configuration options including pipelineId and additional attributes.
  * @returns The wrapped function with the identical type signature as fn.
  */
 export function interaction<F extends (...args: any[]) => any>(
-  pipelineId: string,
+  name: string,
   fn: F,
-  options: TracedOptions = {
-    name: fn.name || ANONYMOUS_SPAN_NAME,
-    attributes: {
-      [ATTR_GENTRACE_PIPELINE_ID]: pipelineId,
-    },
-  },
+  options: InteractionOptions,
 ): F {
-  const fnName = fn.name;
-  const interactionName = options?.name || fnName || ANONYMOUS_SPAN_NAME;
+  const { pipelineId, attributes } = options;
 
   const wrappedFn = traced(fn, {
-    name: interactionName,
+    name: name,
     attributes: {
-      ...options.attributes,
+      ...attributes,
       [ATTR_GENTRACE_PIPELINE_ID]: pipelineId,
     },
   });

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -37,8 +37,7 @@ export function interaction<F extends (...args: any[]) => any>(
 ): F {
   const { pipelineId, attributes } = options;
 
-  const wrappedFn = traced(fn, {
-    name: name,
+  const wrappedFn = traced(name, fn, {
     attributes: {
       ...attributes,
       [ATTR_GENTRACE_PIPELINE_ID]: pipelineId,

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -24,10 +24,11 @@ export type InteractionOptions = {
  * Handles functions that take either zero arguments or one argument which is a record.
  * Preserves the exact type signature (including sync/async return type) of the original function.
  *
- * @param name The name for the span.
- * @param fn The function to wrap. Must take zero args or a single record argument.
- * @param options Configuration options including pipelineId and additional attributes.
- * @returns The wrapped function with the identical type signature as fn.
+ * @template {function} F - The type of the function to wrap.
+ * @param {string} name - The name for the span.
+ * @param {F} fn - The function to wrap. Must take zero args or a single record argument.
+ * @param {InteractionOptions} options - Configuration options including pipelineId and additional attributes.
+ * @returns {F} The wrapped function with the identical type signature as fn.
  */
 export function interaction<F extends (...args: any[]) => any>(
   name: string,

--- a/src/lib/traced.ts
+++ b/src/lib/traced.ts
@@ -23,10 +23,10 @@ export type TracedOptions = {
  * Wraps a function with OpenTelemetry tracing to track its execution.
  * Creates a span for the function execution and records its success or failure.
  *
- * @template F - The type of the function to wrap with tracing.
+ * @template {function} F - The type of the function to wrap with tracing.
  * @param {F} fn - The function to wrap with tracing.
- * @param {TracedOptions} [options] - Optional configuration for tracing.
- * @returns A new function that has the same parameters and return type as fn.
+ * @param {TracedOptions} options - Configuration for tracing.
+ * @returns {F} A new function that has the same parameters and return type as fn.
  */
 export function traced<F extends (...args: any[]) => any>(fn: F, options: TracedOptions): F {
   const tracer = trace.getTracer('gentrace');

--- a/src/lib/traced.ts
+++ b/src/lib/traced.ts
@@ -1,6 +1,5 @@
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
-import { ANONYMOUS_SPAN_NAME } from './constants';
 import { ATTR_GENTRACE_FN_ARGS, ATTR_GENTRACE_FN_OUTPUT } from './otel/constants';
 
 /**
@@ -8,8 +7,9 @@ import { ATTR_GENTRACE_FN_ARGS, ATTR_GENTRACE_FN_OUTPUT } from './otel/constants
  */
 export type TracedOptions = {
   /**
-   * Optional custom name for the span.
-   * Defaults to the function's name or 'anonymousFunction'.
+   * Required name for the span. While function names could be used, build tools may
+   * transpile and change function names, making spans harder to track. Therefore
+   * we require an explicit name.
    */
   name: string;
 
@@ -28,13 +28,7 @@ export type TracedOptions = {
  * @param {TracedOptions} [options] - Optional configuration for tracing.
  * @returns A new function that has the same parameters and return type as fn.
  */
-export function traced<F extends (...args: any[]) => any>(
-  fn: F,
-  options: TracedOptions = {
-    name: fn.name || ANONYMOUS_SPAN_NAME,
-    attributes: {},
-  },
-): F {
+export function traced<F extends (...args: any[]) => any>(fn: F, options: TracedOptions): F {
   const tracer = trace.getTracer('gentrace');
   const fnName = fn.name;
   const spanName = options.name;

--- a/tests/lib/traced.test.ts
+++ b/tests/lib/traced.test.ts
@@ -69,7 +69,7 @@ describe('traced decorator', () => {
       return a + b;
     }
 
-    const tracedAdd = traced(syncAdd, { name: 'syncAdd' });
+    const tracedAdd = traced('syncAdd', syncAdd);
     const result = await tracedAdd(2, 3);
 
     expect(result).toBe(5);
@@ -90,7 +90,7 @@ describe('traced decorator', () => {
       return Promise.resolve(a * b);
     }
 
-    const tracedMultiply = traced(asyncMultiply, { name: 'asyncMultiply' });
+    const tracedMultiply = traced('asyncMultiply', asyncMultiply);
     const result = await tracedMultiply(4, 5);
 
     expect(result).toBe(20);
@@ -111,7 +111,7 @@ describe('traced decorator', () => {
       throw new Error('Sync fail');
     }
 
-    const tracedError = traced(syncError, { name: 'syncError' });
+    const tracedError = traced('syncError', syncError);
 
     expect(() => tracedError()).toThrow('Sync fail');
 
@@ -132,7 +132,7 @@ describe('traced decorator', () => {
       return Promise.reject(new Error('Async fail'));
     }
 
-    const tracedReject = traced(asyncReject, { name: 'asyncReject' });
+    const tracedReject = traced('asyncReject', asyncReject);
 
     await expect(tracedReject()).rejects.toThrow('Async fail');
 
@@ -148,12 +148,12 @@ describe('traced decorator', () => {
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
   });
 
-  it('should use the provided name in options', async () => {
+  it('should use the provided name parameter', async () => {
     async function originalName() {
       return 'result';
     }
 
-    const tracedFn = traced(originalName, { name: 'customSpanName', attributes: {} });
+    const tracedFn = traced('customSpanName', originalName, { attributes: {} });
     await tracedFn();
 
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
@@ -161,12 +161,12 @@ describe('traced decorator', () => {
     expect(mockSpan.end).toHaveBeenCalledTimes(1);
   });
 
-  it('should use the function name if no options name is provided', async () => {
+  it('should correctly use function name when name parameter is the same', async () => {
     async function functionWithName() {
       return 'result';
     }
 
-    const tracedFn = traced(functionWithName, { name: 'functionWithName' });
+    const tracedFn = traced('functionWithName', functionWithName);
     await tracedFn();
 
     expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1);
@@ -175,12 +175,9 @@ describe('traced decorator', () => {
   });
 
   it('should handle functions with complex arguments and return values', async () => {
-    const tracedComplex = traced(
-      async (obj: object, arr: any[]) => {
-        return { ...obj, newProp: arr.length };
-      },
-      { name: 'complexFunction' },
-    );
+    const tracedComplex = traced('complexFunction', async (obj: object, arr: any[]) => {
+      return { ...obj, newProp: arr.length };
+    });
 
     const argObj = { a: 1, b: 'hello' };
     const argArr = [true, null, 123];


### PR DESCRIPTION
### TL;DR

Made interaction names explicit by requiring a name parameter in the `interaction()` options bag.

### What changed?

- Modified the `interaction()` function to require an explicit `name` parameter instead of using function names or a default "anonymous" value
- Removed the `ANONYMOUS_SPAN_NAME` constant and related fallback logic
- Updated all example files to include explicit names for interactions
- Updated the `traced()` function to require a name parameter rather than inferring it
- Updated all tests to accommodate the new required name parameter

### How to test?

1. Run the updated examples to verify they work with the new explicit naming:
   ```
   ts-node examples/no-params.ts
   ts-node examples/openai-composition.ts
   ts-node examples/test-dataset.ts
   ts-node examples/test-openai-composition.ts
   ```
2. Run the test suite to ensure all tests pass with the updated API:
   ```
   npm test
   ```

### Why make this change?

Function names can be unreliable for tracing purposes because:
1. Build tools may transpile and change function names
2. Anonymous functions lack meaningful names
3. Explicit naming provides clearer context in traces and logs

By requiring explicit names, we ensure that spans are consistently and meaningfully labeled, making traces more useful for debugging and monitoring.