### PR TITLE
fix: Update OTLPTraceExporter URL

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,7 +76,7 @@ const sdk = new NodeSDK({
   spanProcessors: [
     new SimpleSpanProcessor(
       new OTLPTraceExporter({
-        url: 'https://api.gentrace.ai/v1/otel/traces',
+        url: 'https://gentrace.ai/api/v1/otel/traces',
         headers: {
           Authorization: \`Bearer \${process.env.GENTRACE_API_KEY}\`,
         },


### PR DESCRIPTION
### TL;DR

Updated the OpenTelemetry trace exporter URL to use the new endpoint format.

### What changed?

Changed the URL for the OpenTelemetry trace exporter from `https://api.gentrace.ai/v1/otel/traces` to `https://gentrace.ai/api/v1/otel/traces`.

### How to test?

1. Ensure the Gentrace API key is set in the environment variables
2. Run a trace export operation
3. Verify that traces are being properly sent to the new endpoint
4. Check that no errors are occurring during the export process

### Why make this change?

The Gentrace API endpoint structure has been updated, requiring clients to use the new URL format. This change ensures compatibility with the current API infrastructure.