### PR TITLE
chore: add example for local test cases

### DIFF
--- a/examples/evaluation-dataset-local-test-cases.ts
+++ b/examples/evaluation-dataset-local-test-cases.ts
@@ -10,7 +10,7 @@
  *    export GENTRACE_BASE_URL="https://gentrace.ai/api"  # optional
  *
  * 2. Run the example:
- *    yarn example examples/evaluation-dataset.ts
+ *    yarn example examples/evaluation-dataset-local-test-cases.ts
  */
 
 import { testCases } from 'gentrace/lib/init';


### PR DESCRIPTION
### TL;DR

Added a new example file for running evaluations with local test cases from a Gentrace dataset.

### What changed?

Created a new file `examples/evaluation-dataset-local-test-cases.ts` that demonstrates how to:
- Initialize Gentrace with OpenTelemetry setup
- Fetch test cases from a Gentrace dataset using the `testCases.list()` API
- Run evaluations against these test cases using the `evalDataset()` function
- Instrument a function with the `interaction()` wrapper
- Validate inputs with Zod schemas

### How to test?

1. Set the required environment variables:
   ```
   export GENTRACE_API_KEY="your-api-key"
   export GENTRACE_PIPELINE_ID="your-pipeline-id"
   export GENTRACE_DATASET_ID="your-dataset-id"
   export GENTRACE_BASE_URL="https://gentrace.ai/api"  # optional
   ```

2. Run the example:
   ```
   yarn example examples/evaluation-dataset-local-test-cases.ts
   ```

### Why make this change?

This example provides a clear demonstration of how to use Gentrace's evaluation capabilities with test cases fetched from a dataset, helping users understand how to implement and run evaluations in their own applications.