### PR TITLE
feat(experiment): return experiment object metadata from `experiment()` invocation

### DIFF
--- a/examples/evaluation-dataset.ts
+++ b/examples/evaluation-dataset.ts
@@ -34,7 +34,6 @@ if (!apiKey) {
 init({
   apiKey,
   baseURL: process.env['GENTRACE_BASE_URL'] || 'https://gentrace.ai/api',
-  otelSetup: true,
 });
 
 async function main() {
@@ -67,9 +66,6 @@ async function main() {
       interaction: instrumentedQueryAi,
     });
   });
-
-  // Wait for spans to flush
-  await new Promise((resolve) => setTimeout(resolve, 2000));
 }
 
 main().catch(console.error);

--- a/examples/evaluation-dataset.ts
+++ b/examples/evaluation-dataset.ts
@@ -53,7 +53,7 @@ async function main() {
   );
 
   // Run an experiment with a simple evaluation
-  await experiment(pipelineId, async () => {
+  const result = await experiment(pipelineId, async () => {
     await evalDataset({
       // Fetch test cases from your Gentrace dataset
       data: async () => {
@@ -66,6 +66,8 @@ async function main() {
       interaction: instrumentedQueryAi,
     });
   });
+
+  console.log('Experiment URL:', result.url);
 }
 
 main().catch(console.error);

--- a/src/lib/experiment-control.ts
+++ b/src/lib/experiment-control.ts
@@ -1,4 +1,5 @@
 import { _getClient } from './client-instance';
+import type { Experiment } from '../resources/experiments';
 
 export type ExperimentMetadata = Record<string, unknown>;
 
@@ -26,9 +27,9 @@ export type StartExperimentParams = {
  * @param {StartExperimentParams} params - The parameters for starting the experiment.
  * @param {string} params.pipelineId - The ID of the pipeline the experiment belongs to.
  * @param {ExperimentMetadata} [params.metadata] - Optional metadata to associate with the experiment run.
- * @returns A promise that resolves with the unique ID of the created experiment run.
+ * @returns A promise that resolves with the created experiment object.
  */
-export async function startExperiment({ pipelineId, metadata }: StartExperimentParams): Promise<string> {
+export async function startExperiment({ pipelineId, metadata }: StartExperimentParams): Promise<Experiment> {
   const client = _getClient();
 
   const experiment = await client.experiments.create({
@@ -56,7 +57,7 @@ export async function startExperiment({ pipelineId, metadata }: StartExperimentP
   process.on('SIGTERM', shutdownListener);
 
   client.logger?.info(`Started experiment ${experimentId} for pipeline ${pipelineId}`);
-  return experimentId;
+  return experiment;
 }
 
 /**

--- a/src/lib/experiment.ts
+++ b/src/lib/experiment.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { finishExperiment, startExperiment, StartExperimentParams } from './experiment-control';
 import type { Experiment } from '../resources/experiments';
+import { _getClient } from './client-instance';
 
 /**
  * Represents the context for an experiment run. This context is stored in
@@ -43,6 +44,11 @@ export type ExperimentOptions = {
 };
 
 /**
+ * The result of an experiment run.
+ */
+export type ExperimentResult = Experiment & { url: string };
+
+/**
  * Runs an experiment: starts it, executes the callback within an async context
  * containing the experiment ID, and finishes the experiment.
  *
@@ -55,12 +61,12 @@ export async function experiment<T>(
   pipelineId: string,
   callback: () => T | Promise<T>,
   options?: ExperimentOptions,
-): Promise<Experiment> {
+): Promise<Experiment & { url: string }> {
   const metadata = options?.metadata;
   const startParams: StartExperimentParams = metadata ? { pipelineId, metadata } : { pipelineId };
 
-  const experimentObj = await startExperiment(startParams);
-  const experimentId = experimentObj.id;
+  const result = await startExperiment(startParams);
+  const experimentId = result.id;
 
   await experimentContextStorage.run({ experimentId, pipelineId }, async () => {
     await callback();
@@ -68,5 +74,8 @@ export async function experiment<T>(
 
   await finishExperiment({ id: experimentId });
 
-  return experimentObj;
+  const client = _getClient();
+  const url = new URL(client.baseURL);
+  const hostname = `${url.protocol}//${url.host}`;
+  return { ...result, url: `${hostname}${result.resourcePath}` };
 }

--- a/src/lib/interaction.ts
+++ b/src/lib/interaction.ts
@@ -87,6 +87,7 @@ export function interaction<F extends (...args: any[]) => any>(
     if (!isOtelConfigured() && !_isGentraceInitialized()) {
       // Check if API key is available in environment variables
       const apiKey = process.env['GENTRACE_API_KEY'];
+
       if (apiKey) {
         // Show auto-initialization warning once (unless suppressed)
         if (!suppressWarnings && !_autoInitWarningIssued) {

--- a/tests/lib/experiment-control.test.ts
+++ b/tests/lib/experiment-control.test.ts
@@ -67,10 +67,10 @@ describe('experiment-control', () => {
       });
     });
 
-    it('should return the experiment ID on successful creation', async () => {
+    it('should return the experiment object on successful creation', async () => {
       mockGentraceClient.experiments.create.mockResolvedValue(mockExperiment);
-      const experimentId = await experimentControlLib.startExperiment(params);
-      expect(experimentId).toBe(mockExperiment.id);
+      const experiment = await experimentControlLib.startExperiment(params);
+      expect(experiment).toEqual(mockExperiment);
     });
 
     it('should register shutdown listeners for SIGINT and SIGTERM', async () => {

--- a/tests/lib/experiment.test.ts
+++ b/tests/lib/experiment.test.ts
@@ -37,7 +37,10 @@ describe('experiment', () => {
 
     const result = await experiment(mockPipelineId, callback, options);
 
-    expect(result).toBe('Callback Result');
+    expect(result).toMatchObject({
+      id: mockExperimentId,
+      url: expect.stringContaining(mockExperimentId),
+    });
     expect(callback).toHaveBeenCalledTimes(1);
 
     expect(runSpy).toHaveBeenCalledWith(

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -18,6 +18,12 @@ export const handlers = [
     return HttpResponse.json(
       {
         id: MOCKED_EXPERIMENT_ID,
+        createdAt: new Date().toISOString(),
+        metadata: null,
+        name: null,
+        pipelineId: 'pipe-123',
+        resourcePath: '/experiments/exp-msw-123',
+        updatedAt: new Date().toISOString(),
       },
       { status: 200 },
     );


### PR DESCRIPTION
**Key changes:**

- Make sure that `experiment()` returns the experiment object. The return value of experiment callback doesn't really matter.
- Augment the experiment object with the full URL constructed using the base URL