### PR TITLE
feat(experiment): support options-based pipelineId

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ const GENTRACE_PIPELINE_ID = process.env['GENTRACE_PIPELINE_ID'];
 
 // 🚧 Add OpenTelemetry setup (view the OTEL section below)
 
-experiment(GENTRACE_PIPELINE_ID, async () => {
+experiment(async () => {
   evalOnce('simple-query-test', async () => {
     const capital = await instrumentedQueryAi({ query: 'What is the capital of France?' });
     // You can add assertions here if needed, exceptions will get captured and recorded on the
@@ -219,7 +219,7 @@ experiment(GENTRACE_PIPELINE_ID, async () => {
     console.log('Test Result:', result);
     return result;
   });
-});
+}, { pipelineId: GENTRACE_PIPELINE_ID });
 ```
 
 To run these tests, simply execute the file:
@@ -257,7 +257,7 @@ const InputSchema = z.object({
   query: z.string(),
 });
 
-experiment(GENTRACE_PIPELINE_ID, async () => {
+experiment(async () => {
   await evalDataset({
     // Fetch test cases from your Gentrace dataset
     data: async () => {
@@ -269,7 +269,7 @@ experiment(GENTRACE_PIPELINE_ID, async () => {
     // Provide the instrumented function to run against each test case
     interaction: instrumentedQueryAi,
   });
-});
+}, { pipelineId: GENTRACE_PIPELINE_ID });
 ```
 
 > [!NOTE]  

--- a/examples/evaluation-dataset.ts
+++ b/examples/evaluation-dataset.ts
@@ -48,27 +48,30 @@ async function main() {
   });
 
   // Run an experiment with a simple evaluation
-  const result = await experiment(pipelineId, async () => {
-    await evalDataset({
-      // Fetch test cases from your Gentrace dataset
-      data: async () => {
-        const testCasesList = await testCases.list({ datasetId });
-        return testCasesList.data;
-      },
-      // Provide the schema to validate the inputs for each test case in the dataset
-      schema: InputSchema,
-      interaction: async (testCase) => {
-        const { query } = testCase.inputs;
+  const result = await experiment(
+    async () => {
+      await evalDataset({
+        // Fetch test cases from your Gentrace dataset
+        data: async () => {
+          const testCasesList = await testCases.list({ datasetId });
+          return testCasesList.data;
+        },
+        // Provide the schema to validate the inputs for each test case in the dataset
+        schema: InputSchema,
+        interaction: async (testCase) => {
+          const { query } = testCase.inputs;
 
-        const completion = await openai.chat.completions.create({
-          model: 'gpt-4.1-nano',
-          messages: [{ role: 'user', content: query }],
-        });
+          const completion = await openai.chat.completions.create({
+            model: 'gpt-4.1-nano',
+            messages: [{ role: 'user', content: query }],
+          });
 
-        return completion.choices[0]?.message?.content || 'No response';
-      },
-    });
-  });
+          return completion.choices[0]?.message?.content || 'No response';
+        },
+      });
+    },
+    { pipelineId },
+  );
 
   console.log('Experiment URL:', result.url);
 }

--- a/examples/evaluation.ts
+++ b/examples/evaluation.ts
@@ -29,22 +29,25 @@ async function main() {
   }
 
   // Run an experiment with a simple evaluation
-  const result = await experiment(pipelineId, async () => {
-    // Evaluate a simple function
-    await evalOnce('math-addition', async () => {
-      const result = 2 + 2;
-      console.log('Math result:', result);
-      return result;
-    });
+  const result = await experiment(
+    async () => {
+      // Evaluate a simple function
+      await evalOnce('math-addition', async () => {
+        const result = 2 + 2;
+        console.log('Math result:', result);
+        return result;
+      });
 
-    // Evaluate a more complex function
-    await evalOnce('string-manipulation', async () => {
-      const input = 'hello world';
-      const result = input.toUpperCase().split(' ').reverse().join(' ');
-      console.log('String result:', result);
-      return result;
-    });
-  });
+      // Evaluate a more complex function
+      await evalOnce('string-manipulation', async () => {
+        const input = 'hello world';
+        const result = input.toUpperCase().split(' ').reverse().join(' ');
+        console.log('String result:', result);
+        return result;
+      });
+    },
+    { pipelineId },
+  );
 
   console.log('Experiment URL: ' + result.url);
 

--- a/src/lib/experiment.ts
+++ b/src/lib/experiment.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { finishExperiment, startExperiment, StartExperimentParams } from './experiment-control';
 import type { Experiment } from '../resources/experiments';
 import { _getClient } from './client-instance';
+import { isValidUUID } from './utils';
 
 /**
  * Represents the context for an experiment run. This context is stored in
@@ -37,10 +38,12 @@ export function getCurrentExperimentContext(): ExperimentContext | undefined {
  *
  * @typedef {Object} ExperimentOptions
  * @property {Record<string, any>} [metadata] - Optional metadata to associate with the experiment.
+ * @property {string} [pipelineId] - The ID of the pipeline to associate with the experiment. Defaults to 'default'.
  * @property {any} [key: string] - Allows for additional arbitrary properties.
  */
 export type ExperimentOptions = {
   metadata?: Record<string, any>;
+  pipelineId?: string;
 };
 
 /**
@@ -52,17 +55,23 @@ export type ExperimentResult = Experiment & { url: string };
  * Runs an experiment: starts it, executes the callback within an async context
  * containing the experiment ID, and finishes the experiment.
  *
- * @param {string} pipelineId - The ID of the pipeline to associate with the experiment.
  * @param {() => T | Promise<T>} callback - The function containing the experiment logic, returning type T.
- * @param {ExperimentOptions} [options] - Optional parameters for the experiment run, including metadata.
+ * @param {ExperimentOptions} [options] - Optional parameters for the experiment run, including metadata and pipelineId.
  * @returns A promise that resolves with the experiment object.
  */
 export async function experiment<T>(
-  pipelineId: string,
   callback: () => T | Promise<T>,
   options?: ExperimentOptions,
 ): Promise<Experiment & { url: string }> {
+  // Use 'default' if no pipelineId is provided
+  const pipelineId = options?.pipelineId ?? 'default';
   const metadata = options?.metadata;
+
+  // Validate UUID format (skip validation for 'default')
+  if (pipelineId !== 'default' && !isValidUUID(pipelineId)) {
+    throw new Error(`Invalid pipelineId: '${pipelineId}'. Must be a valid UUID.`);
+  }
+
   const startParams: StartExperimentParams = metadata ? { pipelineId, metadata } : { pipelineId };
 
   const result = await startExperiment(startParams);

--- a/tests/lib/experiment.test.ts
+++ b/tests/lib/experiment.test.ts
@@ -8,7 +8,7 @@ import { init } from '../../src/lib/init';
 
 describe('experiment', () => {
   const mockExperimentId = 'exp-msw-123';
-  const mockPipelineId = 'pipe-123';
+  const mockPipelineId = '123e4567-e89b-12d3-a456-426614174000';
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,7 +35,7 @@ describe('experiment', () => {
       return 'Callback Result';
     });
 
-    const result = await experiment(mockPipelineId, callback, options);
+    const result = await experiment(callback, { ...options, pipelineId: mockPipelineId });
 
     expect(result).toMatchObject({
       id: mockExperimentId,
@@ -53,7 +53,7 @@ describe('experiment', () => {
 
   it('should work without metadata', async () => {
     const callback = jest.fn<() => void>();
-    await experiment(mockPipelineId, callback);
+    await experiment(callback, { pipelineId: mockPipelineId });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -62,7 +62,7 @@ describe('experiment', () => {
     const callback = jest.fn<() => Promise<void>>(async () => {
       throw error;
     });
-    await expect(experiment(mockPipelineId, callback)).rejects.toThrow(error);
+    await expect(experiment(callback, { pipelineId: mockPipelineId })).rejects.toThrow(error);
   });
 
   it('should finish experiment even if callback throws (sync)', async () => {
@@ -70,7 +70,7 @@ describe('experiment', () => {
     const callback = jest.fn<() => void>(() => {
       throw error;
     });
-    await expect(experiment(mockPipelineId, callback)).rejects.toThrow(error);
+    await expect(experiment(callback, { pipelineId: mockPipelineId })).rejects.toThrow(error);
   });
 
   // TODO: temporarily disabled
@@ -98,7 +98,7 @@ describe('experiment', () => {
       }),
     );
 
-    await expect(experiment(mockPipelineId, callback)).rejects.toThrow(callbackError);
+    await expect(experiment(callback, { pipelineId: mockPipelineId })).rejects.toThrow(callbackError);
   });
 
   describe('getCurrentExperimentContext', () => {
@@ -112,7 +112,7 @@ describe('experiment', () => {
         expect(getCurrentExperimentContext()).toEqual(context);
       });
 
-      await experiment(mockPipelineId, callback);
+      await experiment(callback, { pipelineId: mockPipelineId });
 
       expect(callback).toHaveBeenCalled();
       expect(getCurrentExperimentContext()).toBeUndefined();


### PR DESCRIPTION
This PR is designed to make sure that the pipeline ID is moved into the options object in the second parameter, and also by default, if the pipeline ID is excluded, it passes a default identifier—which will automatically resolve to the default pipeline for that particular organization specified by the API key.