### PR TITLE
fix: add an error for partial ingestion, unify logging with Stainless' logging system

### DIFF
--- a/examples/custom-configuration.ts
+++ b/examples/custom-configuration.ts
@@ -24,6 +24,8 @@ import { generateText } from 'ai';
 init({
   apiKey: process.env['GENTRACE_API_KEY'] || '',
   baseURL: process.env['GENTRACE_BASE_URL'] || 'https://gentrace.ai/api',
+  // To enable debug logging, use logLevel: 'debug'
+  // logLevel: 'debug',
   otelSetup: {
     serviceName: 'my-custom-service',
     sampler: new GentraceSampler(),
@@ -31,7 +33,6 @@ init({
       'service.version': '1.0.0',
       'deployment.environment': process.env['NODE_ENV'] || 'development',
     },
-    debug: true,
   },
 });
 

--- a/examples/custom-configuration.ts
+++ b/examples/custom-configuration.ts
@@ -24,8 +24,7 @@ import { generateText } from 'ai';
 init({
   apiKey: process.env['GENTRACE_API_KEY'] || '',
   baseURL: process.env['GENTRACE_BASE_URL'] || 'https://gentrace.ai/api',
-  // To enable debug logging, use logLevel: 'debug'
-  // logLevel: 'debug',
+  logLevel: 'debug',
   otelSetup: {
     serviceName: 'my-custom-service',
     sampler: new GentraceSampler(),

--- a/examples/genai-semantic-conventions.ts
+++ b/examples/genai-semantic-conventions.ts
@@ -24,7 +24,6 @@ import { init, interaction } from '../src';
 init({
   apiKey: process.env['GENTRACE_API_KEY'] || '',
   baseURL: process.env['GENTRACE_BASE_URL'] || 'https://gentrace.ai/api',
-  logLevel: 'warn',
 });
 
 async function main() {

--- a/examples/genai-semantic-conventions.ts
+++ b/examples/genai-semantic-conventions.ts
@@ -24,7 +24,7 @@ import { init, interaction } from '../src';
 init({
   apiKey: process.env['GENTRACE_API_KEY'] || '',
   baseURL: process.env['GENTRACE_BASE_URL'] || 'https://gentrace.ai/api',
-  otelSetup: true,
+  logLevel: 'warn',
 });
 
 async function main() {

--- a/src/lib/otel/diag-logger.ts
+++ b/src/lib/otel/diag-logger.ts
@@ -1,0 +1,59 @@
+import { DiagLogger } from '@opentelemetry/api';
+import { GentraceWarnings } from '../warnings';
+
+/**
+ * Custom diagnostic logger for OpenTelemetry that intercepts warnings
+ * and displays them using Gentrace's warning system.
+ *
+ * This logger specifically looks for partial success warnings from the
+ * OTLP exporter and displays them using the GT_OtelPartialFailureWarning.
+ */
+export class GentraceDiagLogger implements DiagLogger {
+  constructor(private debugMode: boolean = false) {}
+
+  error(message: string, ...args: unknown[]): void {
+    console.error(`[OpenTelemetry Error] ${message}`, ...args);
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    // Intercept partial success warnings from OTLP exporter
+    if (message.includes('Received Partial Success response:')) {
+      // The partial success data is passed as the first argument
+      const partialSuccessJson = args[0] as string;
+      try {
+        const partialSuccess = JSON.parse(partialSuccessJson);
+
+        // Use Gentrace's warning system to display the partial failure
+        const warning = GentraceWarnings.OtelPartialFailureWarning(
+          partialSuccess.rejectedSpans || 0,
+          partialSuccess.errorMessage,
+        );
+        warning.display();
+      } catch (e) {
+        // If we can't parse the partial success, fall back to console
+        console.warn(`[OpenTelemetry Warning] ${message}`, ...args);
+      }
+    } else {
+      // Other warnings go to console
+      console.warn(`[OpenTelemetry Warning] ${message}`, ...args);
+    }
+  }
+
+  info(message: string, ...args: unknown[]): void {
+    if (this.debugMode) {
+      console.info(`[OpenTelemetry Info] ${message}`, ...args);
+    }
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    if (this.debugMode) {
+      console.debug(`[OpenTelemetry Debug] ${message}`, ...args);
+    }
+  }
+
+  verbose(message: string, ...args: unknown[]): void {
+    if (this.debugMode) {
+      console.debug(`[OpenTelemetry Verbose] ${message}`, ...args);
+    }
+  }
+}

--- a/src/lib/otel/diag-logger.ts
+++ b/src/lib/otel/diag-logger.ts
@@ -1,5 +1,5 @@
 import { DiagLogger } from '@opentelemetry/api';
-import { GentraceWarnings, GentraceWarning } from '../warnings';
+import { GentraceWarnings } from '../warnings';
 import { _getClient } from '../client-instance';
 import { loggerFor } from '../../internal/utils/log';
 

--- a/src/lib/otel/setup.ts
+++ b/src/lib/otel/setup.ts
@@ -10,19 +10,20 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as resources from '@opentelemetry/resources';
-import { 
+import {
   ATTR_SERVICE_NAME,
   ATTR_TELEMETRY_SDK_LANGUAGE,
   ATTR_TELEMETRY_SDK_NAME,
-  ATTR_TELEMETRY_SDK_VERSION
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import { setGlobalErrorHandler, SDK_INFO } from '@opentelemetry/core';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { GentraceWarnings } from '../warnings';
-import { diag, DiagLogLevel } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import { GentraceDiagLogger } from './diag-logger';
 import { loggerFor } from '../../internal/utils/log';
+import { mapStainlessLogLevelToOTelDiagLevel } from './utils';
 
 // Re-export SetupConfig for backwards compatibility
 export type { SetupConfig };
@@ -137,7 +138,8 @@ setup();`;
 
   // Configure the diagnostic logger to intercept OpenTelemetry warnings
   // This allows us to display partial success warnings using Gentrace's warning system
-  diag.setLogger(new GentraceDiagLogger(), DiagLogLevel.WARN);
+  const diagLogLevel = mapStainlessLogLevelToOTelDiagLevel(client.logLevel);
+  diag.setLogger(new GentraceDiagLogger(), diagLogLevel);
 
   // Set a custom error handler for OpenTelemetry
   setGlobalErrorHandler((error) => {

--- a/src/lib/otel/setup.ts
+++ b/src/lib/otel/setup.ts
@@ -5,7 +5,6 @@ import { _isGentraceInitialized } from '../init-state';
 import boxen from 'boxen';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
-import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import type { SetupConfig } from './types';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
@@ -15,6 +14,9 @@ import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { setGlobalErrorHandler } from '@opentelemetry/core';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { GentraceWarnings } from '../warnings';
+import { diag, DiagLogLevel } from '@opentelemetry/api';
+import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
+import { GentraceDiagLogger } from './diag-logger';
 
 // Re-export SetupConfig for backwards compatibility
 export type { SetupConfig };
@@ -125,6 +127,10 @@ setup();`;
     warning.display();
     throw new Error('Gentrace API key is missing or invalid.');
   }
+
+  // Configure the diagnostic logger to intercept OpenTelemetry warnings
+  // This allows us to display partial success warnings using Gentrace's warning system
+  diag.setLogger(new GentraceDiagLogger(config.debug), DiagLogLevel.WARN);
 
   // Set a custom error handler for OpenTelemetry
   setGlobalErrorHandler((error) => {

--- a/src/lib/otel/types.ts
+++ b/src/lib/otel/types.ts
@@ -28,9 +28,4 @@ export interface SetupConfig {
    * Optional custom sampler
    */
   sampler?: Sampler;
-
-  /**
-   * Whether to include console exporter for debugging (defaults to false)
-   */
-  debug?: boolean;
 }

--- a/src/lib/otel/utils.ts
+++ b/src/lib/otel/utils.ts
@@ -1,0 +1,42 @@
+import { DiagLogLevel } from '@opentelemetry/api';
+import type { LogLevel } from '../../internal/utils/log';
+
+/**
+ * Maps Stainless SDK LogLevel strings to OpenTelemetry DiagLogLevel enum values.
+ *
+ * The Stainless SDK uses lowercase string values for log levels:
+ * - 'off': Disable all logging
+ * - 'error': Log only errors
+ * - 'warn': Log warnings and errors
+ * - 'info': Log info, warnings, and errors
+ * - 'debug': Log everything including debug messages
+ *
+ * OpenTelemetry uses numeric enum values:
+ * - NONE (0): No logging
+ * - ERROR (30): Error logging
+ * - WARN (50): Warning logging
+ * - INFO (60): Info logging
+ * - DEBUG (70): Debug logging
+ * - VERBOSE (80): Verbose logging (not used by Stainless)
+ * - ALL (9999): All logging
+ *
+ * @param logLevel - The Stainless SDK log level string
+ * @returns The corresponding OpenTelemetry DiagLogLevel enum value
+ */
+export function mapStainlessLogLevelToOTelDiagLevel(logLevel: LogLevel | undefined): DiagLogLevel {
+  switch (logLevel) {
+    case 'off':
+      return DiagLogLevel.NONE;
+    case 'error':
+      return DiagLogLevel.ERROR;
+    case 'warn':
+      return DiagLogLevel.WARN;
+    case 'info':
+      return DiagLogLevel.INFO;
+    case 'debug':
+      return DiagLogLevel.DEBUG;
+    default:
+      // Default to WARN if logLevel is undefined or unrecognized
+      return DiagLogLevel.WARN;
+  }
+}

--- a/src/lib/warnings.ts
+++ b/src/lib/warnings.ts
@@ -253,11 +253,11 @@ export const GentraceWarnings = {
   OtelPartialFailureWarning: (rejectedCount: number, errorMessage?: string) =>
     new GentraceWarning({
       warningId: 'GT_OtelPartialFailureWarning',
-      title: 'OpenTelemetry Partial Export Failure',
+      title: 'Some spans were not ingested',
       message: [
-        `Failed to export ${rejectedCount} spans to Gentrace.`,
+        `Gentrace could not ingest ${rejectedCount} ${rejectedCount === 1 ? 'span' : 'spans'}.`,
         '',
-        `Error: ${errorMessage || 'Some spans were rejected by the server'}`,
+        `Reason: ${errorMessage || `The server rejected ${rejectedCount === 1 ? 'this span' : 'these spans'}`}`,
         '',
         'This may indicate:',
         '• Invalid span data or attributes',
@@ -265,7 +265,7 @@ export const GentraceWarnings = {
         '• Server-side validation failures',
       ],
       learnMoreUrl: 'https://next.gentrace.ai/docs/sdk-reference/errors#gt-otelpartialfailurewarning',
-      suppressionHint: 'Partial failures are logged but do not stop span export',
-      borderColor: 'yellow',
+      suppressionHint: 'This warning will only be shown once per session',
+      borderColor: 'red',
     }),
 };

--- a/src/lib/warnings.ts
+++ b/src/lib/warnings.ts
@@ -249,4 +249,23 @@ export const GentraceWarnings = {
       learnMoreUrl: 'https://next.gentrace.ai/docs/sdk-reference/errors#gt-multipleinitwarning',
       suppressionHint: 'To suppress this warning: init({ ..., suppressWarnings: true })',
     }),
+
+  OtelPartialFailureWarning: (rejectedCount: number, errorMessage?: string) =>
+    new GentraceWarning({
+      warningId: 'GT_OtelPartialFailureWarning',
+      title: 'OpenTelemetry Partial Export Failure',
+      message: [
+        `Failed to export ${rejectedCount} spans to Gentrace.`,
+        '',
+        `Error: ${errorMessage || 'Some spans were rejected by the server'}`,
+        '',
+        'This may indicate:',
+        '• Invalid span data or attributes',
+        '• Rate limiting or quota issues',
+        '• Server-side validation failures',
+      ],
+      learnMoreUrl: 'https://next.gentrace.ai/docs/sdk-reference/errors#gt-otelpartialfailurewarning',
+      suppressionHint: 'Partial failures are logged but do not stop span export',
+      borderColor: 'yellow',
+    }),
 };

--- a/src/lib/warnings.ts
+++ b/src/lib/warnings.ts
@@ -1,6 +1,9 @@
 import chalk from 'chalk';
 import boxen from 'boxen';
 
+// Global tracking of displayed warnings
+const displayedWarnings = new Set<string>();
+
 export interface GentraceWarningOptions {
   warningId: string;
   title: string;
@@ -31,7 +34,37 @@ export class GentraceWarning {
     return this.message.join(' ');
   }
 
+  /**
+   * Check if a warning has already been displayed
+   */
+  static hasBeenDisplayed(warningKey: string): boolean {
+    return displayedWarnings.has(warningKey);
+  }
+
+  /**
+   * Mark a warning as displayed
+   */
+  static markAsDisplayed(warningKey: string): void {
+    displayedWarnings.add(warningKey);
+  }
+
+  /**
+   * Clear all displayed warnings (used for testing)
+   * @internal
+   */
+  static _clearDisplayedWarnings(): void {
+    displayedWarnings.clear();
+  }
+
   display(): void {
+    // Check if this warning has already been displayed
+    if (GentraceWarning.hasBeenDisplayed(this.warningId)) {
+      return;
+    }
+
+    // Mark as displayed
+    GentraceWarning.markAsDisplayed(this.warningId);
+
     try {
       // Build the formatted message
       const messageLines: string[] = [];

--- a/tests/lib/init-warnings.test.ts
+++ b/tests/lib/init-warnings.test.ts
@@ -133,7 +133,7 @@ describe('Multiple init() warning tests', () => {
       // First sequence
       init({ apiKey: 'key1', otelSetup: false });
       init({ apiKey: 'key2', otelSetup: false });
-      
+
       expect(consoleWarnMock).toHaveBeenCalledTimes(1);
       const firstWarning = consoleWarnMock.mock.calls[0]?.[0] || '';
       expect(firstWarning).toContain('2 times');
@@ -144,7 +144,7 @@ describe('Multiple init() warning tests', () => {
 
       // Second sequence - should show warning again
       init({ apiKey: 'key3', otelSetup: false });
-      
+
       expect(consoleWarnMock).toHaveBeenCalledTimes(1);
       const secondWarning = consoleWarnMock.mock.calls[0]?.[0] || '';
       expect(secondWarning).toContain('3 times');

--- a/tests/lib/init-warnings.test.ts
+++ b/tests/lib/init-warnings.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { init } from 'gentrace';
 import { _getInitHistory } from 'gentrace/lib/init-state';
+import { GentraceWarning } from 'gentrace/lib/warnings';
 
 describe('Multiple init() warning tests', () => {
   let originalConsoleWarn: typeof console.warn;
@@ -15,6 +16,9 @@ describe('Multiple init() warning tests', () => {
     // Clear init history before each test
     const history = _getInitHistory();
     history.length = 0;
+
+    // Clear displayed warnings before each test
+    GentraceWarning._clearDisplayedWarnings();
   });
 
   afterEach(() => {
@@ -111,16 +115,38 @@ describe('Multiple init() warning tests', () => {
       expect(warningOutput).toContain('- true → false');
     });
 
-    test('should track multiple init calls in history', () => {
+    test('should show warning only once with deduplication', () => {
       init({ apiKey: 'key1', otelSetup: false });
       init({ apiKey: 'key2', otelSetup: false });
       init({ apiKey: 'key3', otelSetup: false });
 
-      // Should have shown warnings for the 2nd and 3rd calls
-      expect(consoleWarnMock).toHaveBeenCalledTimes(2);
+      // Due to warning deduplication, should only show warning once (on the 2nd call)
+      expect(consoleWarnMock).toHaveBeenCalledTimes(1);
 
-      // Check the second warning (3rd init call)
-      const secondWarning = consoleWarnMock.mock.calls[1]?.[0] || '';
+      // Check the warning shows it was the 2nd call
+      const warningOutput = consoleWarnMock.mock.calls[0]?.[0] || '';
+      expect(warningOutput).toContain('2 times');
+      expect(warningOutput).toContain('Call #1:');
+    });
+
+    test('should track correct call count after clearing warnings', () => {
+      // First sequence
+      init({ apiKey: 'key1', otelSetup: false });
+      init({ apiKey: 'key2', otelSetup: false });
+      
+      expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+      const firstWarning = consoleWarnMock.mock.calls[0]?.[0] || '';
+      expect(firstWarning).toContain('2 times');
+
+      // Clear warnings and console mock
+      GentraceWarning._clearDisplayedWarnings();
+      consoleWarnMock.mockClear();
+
+      // Second sequence - should show warning again
+      init({ apiKey: 'key3', otelSetup: false });
+      
+      expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+      const secondWarning = consoleWarnMock.mock.calls[0]?.[0] || '';
       expect(secondWarning).toContain('3 times');
       expect(secondWarning).toContain('Call #1:');
       expect(secondWarning).toContain('Call #2:');
@@ -189,7 +215,7 @@ describe('Multiple init() warning tests', () => {
       });
       init({
         apiKey: 'test',
-        otelSetup: { serviceName: 'prod-service', debug: true },
+        otelSetup: { serviceName: 'prod-service' },
       });
 
       const warningOutput = consoleWarnMock.mock.calls[0]?.[0] || '';
@@ -197,7 +223,6 @@ describe('Multiple init() warning tests', () => {
       // Should show object summary
       expect(warningOutput).toContain('otelSetup:');
       expect(warningOutput).toContain('{ serviceName }');
-      expect(warningOutput).toContain('{ serviceName, debug }');
     });
 
     test('should handle array values in config', () => {


### PR DESCRIPTION
- Show errors for partial ingestion
- Unify the warning system
- Use `logLevel` and `logger` parameters for Stainless to inform how OTEL logger and our own boxed errors and warnings are emitted.