### PR TITLE
feat: add gentrace.in_experiment baggage key

### DIFF
--- a/src/lib/eval-once.ts
+++ b/src/lib/eval-once.ts
@@ -1,12 +1,13 @@
-import { Span, SpanStatusCode, trace, context, propagation } from '@opentelemetry/api';
+import { context, propagation, Span, SpanStatusCode, trace } from '@opentelemetry/api';
 import stringify from 'json-stringify-safe';
-import { getCurrentExperimentContext } from './experiment'; // Assuming this provides the experimentId
-import { type ParseableSchema, type TestInput } from './eval-dataset'; // Import the interface
 import { _getClient } from './client-instance';
+import { type ParseableSchema, type TestInput } from './eval-dataset'; // Import the interface
+import { getCurrentExperimentContext } from './experiment'; // Assuming this provides the experimentId
 import {
   ATTR_GENTRACE_EXPERIMENT_ID,
   ATTR_GENTRACE_FN_ARGS,
   ATTR_GENTRACE_FN_OUTPUT,
+  ATTR_GENTRACE_IN_EXPERIMENT,
   ATTR_GENTRACE_SAMPLE,
 } from './otel/constants';
 import { checkOtelConfigAndWarn } from './utils';
@@ -111,9 +112,9 @@ export async function _runEval<
     const currentContext = context.active();
     const currentBaggage = propagation.getBaggage(currentContext) ?? propagation.createBaggage();
 
-    const newBaggage = currentBaggage.setEntry(ATTR_GENTRACE_SAMPLE, {
-      value: 'true',
-    });
+    const newBaggage = currentBaggage
+      .setEntry(ATTR_GENTRACE_SAMPLE, { value: 'true' })
+      .setEntry(ATTR_GENTRACE_IN_EXPERIMENT, { value: 'true' });
     const newContext = propagation.setBaggage(currentContext, newBaggage);
 
     context.with(newContext, () => {

--- a/src/lib/otel/constants.ts
+++ b/src/lib/otel/constants.ts
@@ -4,6 +4,14 @@
  */
 export const ATTR_GENTRACE_SAMPLE = 'gentrace.sample';
 
+
+/**
+ * Key used to identify spans that are part of a Gentrace experiment.
+ * When set to 'true', indicates that the span was created during an experiment run.
+ */
+
+export const ATTR_GENTRACE_IN_EXPERIMENT = 'gentrace.in_experiment';
+
 /**
  * Key used to identify which Gentrace pipeline a particular span belongs to.
  * Spans tagged with this attribute will be viewable in the "Traces" section of the Gentrace dashboard.

--- a/src/lib/otel/span-processor.ts
+++ b/src/lib/otel/span-processor.ts
@@ -1,6 +1,8 @@
 import { Context, propagation } from '@opentelemetry/api';
 import { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { ATTR_GENTRACE_SAMPLE } from './constants';
+import { ATTR_GENTRACE_IN_EXPERIMENT, ATTR_GENTRACE_SAMPLE } from './constants';
+
+const gentraceBaggageKeys = [ATTR_GENTRACE_SAMPLE, ATTR_GENTRACE_IN_EXPERIMENT];
 
 /**
  * A function that determines whether a baggage key-value pair should be added to new
@@ -32,7 +34,7 @@ export class GentraceSpanProcessor implements SpanProcessor {
    */
   onStart(span: Span, parentContext: Context): void {
     (propagation.getBaggage(parentContext)?.getAllEntries() ?? [])
-      .filter((entry) => entry[0] === ATTR_GENTRACE_SAMPLE)
+      .filter((entry) => gentraceBaggageKeys.includes(entry[0]))
       .forEach((entry) => span.setAttribute(entry[0], entry[1].value));
   }
 


### PR DESCRIPTION
### TL;DR

Added support for tracking whether spans are part of an experiment with a new baggage attribute.

### What changed?

- Added a new constant `ATTR_GENTRACE_IN_EXPERIMENT` to track when spans are part of an experiment
- Modified the `_runEval` function to set this new attribute in the baggage
- Updated the `GentraceSpanProcessor` to propagate both sampling and experiment attributes from baggage to spans
- Created a `gentraceBaggageKeys` array to maintain the list of baggage keys that should be propagated to spans

### How to test?

1. Run an experiment using the SDK
2. Verify that spans created during the experiment have both the `gentrace.sample` and `gentrace.in_experiment` attributes set to "true"
3. Check that these attributes are properly propagated through the span hierarchy

### Why make this change?

This change enables better tracking of spans that are specifically part of experiments, allowing for improved filtering and analysis of experiment-related telemetry data. The distinction between regular sampling and experiment participation provides more context for understanding trace data.